### PR TITLE
Show container info even if entrypoint is empty

### DIFF
--- a/app/models/concerns/fog_extensions/fogdocker/server.rb
+++ b/app/models/concerns/fog_extensions/fogdocker/server.rb
@@ -10,9 +10,9 @@ module FogExtensions
       end
 
       def command
-        c=[]
-        c += entrypoint if entrypoint.any?
-        c += cmd if cmd.any?
+        c = []
+        c += entrypoint if entrypoint.present?
+        c += cmd if cmd.present?
         c.join(' ')
       end
 


### PR DESCRIPTION
ENTRYPOINT and CMD might be nil on the container. In this case, the
current code just throws a 500 because it's checking for .any? on a nil
object instead of .present?
