### PR TITLE
Add docker RABL to API

### DIFF
--- a/app/views/api/v1/compute_resources/docker.json
+++ b/app/views/api/v1/compute_resources/docker.json
@@ -1,0 +1,1 @@
+attributes :user

--- a/app/views/api/v2/compute_resources/docker.json
+++ b/app/views/api/v2/compute_resources/docker.json
@@ -1,0 +1,1 @@
+attributes :user


### PR DESCRIPTION
Without this template, compute_resources/main.json.rabl will look for a
docker.json template with no avail. This results in failed
api/compute_resources index and show calls (for Docker CRs).
