### PR TITLE
fixes #8100 - make engine and asset precompilation name consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/dummy/tmp/
 test/dummy/.sass-cache
 .ruby-version
 .ruby-gemset
+public/assets/

--- a/lib/foreman_docker/engine.rb
+++ b/lib/foreman_docker/engine.rb
@@ -9,6 +9,8 @@ module ForemanDocker
   # Inherit from the Rails module of the parent app (Foreman), not the plugin.
   # Thus, inherits from ::Rails::Engine and not from Rails::Engine
   class Engine < ::Rails::Engine
+    engine_name 'foreman_docker'
+
     initializer 'foreman_docker.load_app_instance_data' do |app|
       app.config.paths['db/migrate'] += ForemanDocker::Engine.paths['db/migrate'].existent
     end
@@ -18,7 +20,7 @@ module ForemanDocker
     end
 
     initializer 'foreman_docker.configure_assets', :group => :assets do
-      SETTINGS[:foreman_docker_engine] =
+      SETTINGS[:foreman_docker] =
         { :assets => { :precompile => ['foreman_docker/terminal.css',
                                        'foreman_docker/image_step.js'] } }
     end


### PR DESCRIPTION
Ensures that when precompiling, both the assets and the manifest end up under
'foreman_docker' rather than one ending up under 'foreman_docker_engine'.  Not
much functional effect except it keeps everything in one dir.
