### PR TITLE
Fixes #7872 - Create container without Fog to assign name

### DIFF
--- a/app/controllers/containers/steps_controller.rb
+++ b/app/controllers/containers/steps_controller.rb
@@ -29,7 +29,12 @@ module Containers
         @container.update_attributes(params[:container])
       when :environment
         @container.update_attributes(params[:container])
-        @container.uuid = start_container.id
+        if (response = start_container)
+          @container.uuid = response.id
+        else
+          process_error(:object => @container.compute_resource, :render => 'environment')
+          return
+        end
       end
       render_wizard @container
     end
@@ -51,7 +56,7 @@ module Containers
     end
 
     def start_container
-      @container.compute_resource.create_vm(@container.parametrize)
+      @container.compute_resource.create_container(@container.parametrize)
     end
   end
 end

--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -8,11 +8,12 @@ class Container < ActiveRecord::Base
                   :attach_stdout, :attach_stderr, :tag, :uuid
 
   def parametrize
-    { :name => name, :image => tag.tag.blank? ? image.image_id : "#{image.image_id}:#{tag.tag}",
-      :tty  => tty, :memory => memory,
-      :entrypoint => entrypoint.try(:split), :cmd => command.try(:split),
-      :attach_stdout => attach_stdout, :attach_stdout => attach_stdout,
-      :attach_stderr => attach_stderr, :cpushares => cpu_shares, :cpuset => cpu_set }
+    { 'name'  => name, # key has to be lower case to be picked up by the Docker API
+      'Image' => tag.tag.blank? ? image.image_id : "#{image.image_id}:#{tag.tag}",
+      'Tty'          => tty,                    'Memory'       => memory,
+      'Entrypoint'   => entrypoint.try(:split), 'Cmd'          => command.try(:split),
+      'AttachStdout' => attach_stdout,          'AttachStdin'  => attach_stdin,
+      'AttachStderr' => attach_stderr,          'CpuShares'    => cpu_shares, :cpuset => cpu_set }
   end
 
   def in_fog

--- a/app/models/foreman_docker/docker.rb
+++ b/app/models/foreman_docker/docker.rb
@@ -55,13 +55,13 @@ module ForemanDocker
       'Docker'
     end
 
-    def create_vm(args = {})
+    def create_container(args = {})
       options = vm_instance_defaults.merge(args)
-      logger.debug("creating Docker with the following options: #{options.inspect}")
-      client.servers.create options
-    rescue Excon::Errors::SocketError, Fog::Errors::Error => e
+      logger.debug("Creating container with the following options: #{options.inspect}")
+      ::Docker::Container.create(options)
+    rescue Excon::Errors::Error, ::Docker::Error::DockerError => e
       logger.debug "Fog error: #{e.message}\n " + e.backtrace.join("\n ")
-      errors.add(:base, e.message.to_s)
+      errors.add(:base, _("Error creating container. Check the Foreman logs: %s") % e.message.to_s)
       false
     end
 

--- a/test/functionals/containers_steps_controller_test.rb
+++ b/test/functionals/containers_steps_controller_test.rb
@@ -18,18 +18,30 @@ module Containers
       assert_equal DockerTag.find_by_tag('latest'), @container.tag
     end
 
-    test 'uuid of the created container is saved at the end of the wizard' do
-      Fog.mock!
-      @container.update_attribute(:image, (image = FactoryGirl.create(:docker_image,
-                                                                      :image_id => 'centos')))
-      @container.update_attribute(:tag, FactoryGirl.create(:docker_tag, :image => image,
-                                                                        :tag   => 'latest'))
-      fake_container    = @container.compute_resource.create_vm
-      fake_container.id = SecureRandom.uuid
-      ForemanDocker::Docker.any_instance.expects(:create_vm).returns(fake_container)
-      put :update, { :id => :environment,
-                     :container_id => @container.id }, set_session_user
-      assert_equal fake_container.id, Container.find(@container.id).uuid
+    context 'container creation' do
+      setup do
+        @container.update_attribute(:image, (image = FactoryGirl.create(:docker_image,
+                                                                        :image_id => 'centos')))
+        @container.update_attribute(:tag, FactoryGirl.create(:docker_tag, :image => image,
+                                                                          :tag   => 'latest'))
+      end
+
+      test 'uuid of the created container is saved at the end of the wizard' do
+        Fog.mock!
+        fake_container = @container.compute_resource.send(:client).servers.first
+        ForemanDocker::Docker.any_instance.expects(:create_container).returns(fake_container)
+        put :update, { :id           => :environment,
+                       :container_id => @container.id }, set_session_user
+        assert_equal fake_container.id, Container.find(@container.id).uuid
+      end
+
+      test 'errors are displayed when container creation fails' do
+        Docker::Container.expects(:create).raises(Docker::Error::DockerError, 'some error')
+        put :update, { :id           => :environment,
+                       :container_id => @container.id }, set_session_user
+        assert_template 'environment'
+        assert_match(/some error/, flash[:error])
+      end
     end
 
     test 'wizard finishes with a redirect to the managed container' do


### PR DESCRIPTION
Fog is currently making the key 'name' camelcase which is preventing the
Docker API from picking it up and use it as a name. Until Fog is
patched, we should use docker-api to set the name properly.
