### PR TITLE
Fixes #8329 - Search images in the hub

### DIFF
--- a/app/assets/javascripts/foreman_docker/image_step.js
+++ b/app/assets/javascripts/foreman_docker/image_step.js
@@ -2,6 +2,7 @@ $(document).ready(function() {
   var tag = $('#tag');
   tag.autocomplete({
     source: [],
+    autoFocus: true,
     delay: 500,
     minLength: 0
   }).focus( function() {
@@ -28,6 +29,7 @@ function autoCompleteImage(item) {
         $('#search-addon').removeClass('glyphicon-remove');
         $('#search-addon').css('color', 'lightgreen');
         $('#search-addon').addClass('glyphicon-ok');
+        setWaitingText('Image found: <strong>' + item.val() + '</strong>. Retrieving available tags, please wait...');
         setAutocompleteTags();
       } else {
         $('#search-addon').attr('title', 'Image NOT found in the compute resource');
@@ -47,10 +49,42 @@ function setAutocompleteTags() {
   var source = [];
   $.getJSON( tag.data("url"), { search: $('#search').val() },
       function(data) {
+        $('#searching_spinner').hide();
         tag.removeClass('tags-autocomplete-loading');
         $.each( data, function(index, value) {
           source.push({label: value.label, value: value.value});
         });
+        $('#tag').focus();
       });
   tag.autocomplete('option', 'source', source);
+}
+
+function searchImage(item) {
+  setWaitingText('<strong>Searching</strong> in the hub, this can be slow, please wait...');
+  $('#image_search_results').html('');
+  $('#image_search_results').show();
+  $.ajax({
+    type:'get',
+    dataType:'text',
+    url: $(item).attr('data-url'),
+    data:'search=' + $('#search').val(),
+    success: function (result) {
+      $('#image_search_results').html(result);
+    },
+    complete: function (result) {
+      $('#searching_spinner').hide();
+    }
+  });
+}
+
+function imageSelected(item) {
+  $('#image_search_results').hide();
+  setWaitingText('Image selected: <strong>' + item.text + '</strong>. Retrieving available tags, please wait...');
+  $('#search').val(item.text);
+  setAutocompleteTags(item);
+}
+
+function setWaitingText(string) {
+  $('#waiting_text').html(string);
+  $('#searching_spinner').show();
 }

--- a/app/helpers/containers_helper.rb
+++ b/app/helpers/containers_helper.rb
@@ -51,4 +51,12 @@ module ContainersHelper
     addClass options, 'form-control'
     text_field_tag(name, val, options)
   end
+
+  def hub_url(image)
+    if image['is_official']
+      "https://registry.hub.docker.com/_/#{image['name']}"
+    else
+      "https://registry.hub.docker.com/u/#{image['name']}"
+    end
+  end
 end

--- a/app/views/containers/_image_search_results.html.erb
+++ b/app/views/containers/_image_search_results.html.erb
@@ -1,0 +1,12 @@
+<% images.each do |image| %>
+    <h3><%= link_to image['name'], '#', :onclick => 'imageSelected(this)' %></h3>
+    <p>
+      <%= '<span class="glyphicon glyphicon-certificate" title="Official"></span>'.html_safe if image['is_official'] %>
+      <%= '<span class="glyphicon glyphicon-thumbs-up" title="Trusted"></span>'.html_safe    if image['is_trusted'] %>
+      <span class="glyphicon glyphicon-star"></span> <%= image['star_count'] %>
+    </p>
+    <p>
+      <%= trunc(image['description']) %>
+      <%= link_to '<span class="glyphicon glyphicon-share"></span>'.html_safe, hub_url(image), :target => '_blank' %>
+    </p>
+<% end %>

--- a/app/views/containers/show.html.erb
+++ b/app/views/containers/show.html.erb
@@ -121,8 +121,8 @@
         </div>
         <div class="form-group">
           <%= label_tag "commit[tag]", _("Tag"), :class=>"col-sm-2 control-label" %>
-          <%= text_field :commit, :tag, { :class => "col-sm-8", :focus_on_load => true,
-                                           :placeholder => _('latest') } %>
+          <%= text_field :commit, :tag, { :class => "col-sm-8",
+                                          :placeholder => _('latest') } %>
         </div>
         <div class="form-group">
           <%= label_tag "commit[author]", _("Author"), :class=>"col-sm-2 control-label" %>

--- a/app/views/containers/steps/image.html.erb
+++ b/app/views/containers/steps/image.html.erb
@@ -1,8 +1,6 @@
 <%= javascript 'foreman_docker/image_step' %>
 <%= stylesheet 'foreman_docker/autocomplete' %>
 <%= render :layout => 'title', :locals => { :step => 2 } do %>
-  <%= form_for @container, :url => wizard_path, :method => :put do |f| %>
-
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a href="#primary" data-toggle="tab">
       <span class="glyphicon glyphicon-cloud-download"></span>
@@ -10,31 +8,43 @@
     </a></li>
   </ul>
 
+  <%= form_for @container, :class => 'form-horizontal', :url => wizard_path, :method => :put do |f| %>
+
   <div class="tab-content">
     <div class="tab-pane active" id="hub">
-      <div class="input-group col-md-6">
-        <%= auto_complete_search(:image, '',
-                                 :'data-url'  => auto_complete_image_container_path(@container),
-                                 :value       => f.object.image.present? ? f.object.image.image_id : '',
-                                 :id          => :search,
-                                 :placeholder => _('Find your favorite container, e.g: centos:latest')) %>
-        <span class="input-group-addon glyphicon" id="search-addon"></span>
-        <span class="input-group-btn">
-          <%= button_tag(:class => 'btn btn-default',
-                         :type => 'button',
-                         :onclick => "$('#search').trigger('focus')") do %>
+      <div class="form-group col-md-6">
+        <%= label_tag "image[search]", _('Search'), :class=>"col-sm-2 control-label" %>
+        <div class="input-group">
+          <%= auto_complete_search(:image, '',
+                                   :'data-url'  => auto_complete_image_container_path(@container),
+                                   :value       => f.object.image.present? ? f.object.image.image_id : '',
+                                   :id          => :search,
+                                   :focus_on_load => true,
+                                   :placeholder => _('Find your favorite container, e.g: centos')) %>
+          <span class="input-group-addon glyphicon" id="search-addon"></span>
+          <span class="input-group-btn">
+            <%= button_tag(:class      => 'btn btn-default',
+                           :type       => 'button',
+                           :id         => 'search_image',
+                           :'data-url' => search_image_container_path(@container),
+                           :onclick    => 'searchImage(this)') do %>
             <span class="glyphicon glyphicon-search"></span>
-            <%= _("Search") %>
-          <% end %>
-        </span>
+            <% end %>
+          </span>
+        </div>
       </div>
-      <br/>
-      <div class="input-group col-md-6">
-        <%= text_f f, :tag,
-                      :size       => 'col-md-6',
-                      :value      => f.object.tag.present? ? f.object.tag.tag : '',
-                      :id         => 'tag',
-                      :'data-url' => auto_complete_image_tags_container_path(@container) %>
+      <%= text_f f, :tag,
+                    :value      => f.object.tag.present? ? f.object.tag.tag : '',
+                    :id         => 'tag',
+                    :'data-url' => auto_complete_image_tags_container_path(@container) %>
+      <div class="col-md-12">
+        <div id='searching_spinner' class='col-md-offset-3 hide'>
+          <span id='waiting_text'>
+          </span>
+          <%= image_tag('/assets/spinner.gif', :id => 'loading_images_indicator') %>
+        </div>
+        <div id='image_search_results'>
+        </div>
       </div>
       <hr/>
       <%= render :partial => 'form_buttons' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
       post :commit
     end
     resources :steps, :controller => 'containers/steps', :only => [:show, :update]
-    get :auto_complete_image, :on => :member
+    get :auto_complete_image,      :on => :member
     get :auto_complete_image_tags, :on => :member
+    get :search_image,             :on => :member
   end
 end

--- a/lib/foreman_docker/engine.rb
+++ b/lib/foreman_docker/engine.rb
@@ -50,7 +50,8 @@ module ForemanDocker
         security_block :containers do
           permission :view_containers,    :containers         => [:index, :show,
                                                                   :auto_complete_image,
-                                                                  :auto_complete_image_tags]
+                                                                  :auto_complete_image_tags,
+                                                                  :search_image]
           permission :commit_containers,  :containers         => [:commit]
           permission :create_containers,  :'containers/steps' => [:show, :update],
                                           :containers         => [:new]

--- a/test/integration/container_steps_test.rb
+++ b/test/integration/container_steps_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ContainerStepsTest < ActionDispatch::IntegrationTest
+  test 'shows a link to a new compute resource if none is available'  do
+    visit new_container_path
+    assert has_selector?("div.alert", :text => 'Please add a new one')
+  end
+
+  # test 'clicking on search loads images' do
+  #   Capybara.javascript_driver = :webkit
+  #   container = FactoryGirl.create(:container)
+  #   visit container_step_path(:container_id => container.id, :id => :image)
+  #   ComputeResource.any_instance.expects(:search).returns([{ 'name' => 'my_fake_image_result',
+  #                                                             'star_count' => 300,
+  #                                                             'description' => 'fake image'}])
+  #   click_button 'search_image'
+  #   assert has_link? 'my_fake_image_result'
+  # end
+end

--- a/test/integration/container_test.rb
+++ b/test/integration/container_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ContainerIntegrationTest < ActionDispatch::IntegrationTest
+  test 'redirects to a new compute resource if none is available'  do
+    visit containers_path
+    assert_equal current_path, new_compute_resource_path
+  end
+
+  context 'available compute resource' do
+    test 'shows containers list if compute resource is available' do
+      ComputeResource.any_instance.stubs(:vms).returns([])
+      FactoryGirl.create(:docker_cr)
+      visit containers_path
+      assert page.has_link? 'New container'
+      refute_equal current_path, new_compute_resource_path
+    end
+  end
+end

--- a/test/units/container_test.rb
+++ b/test/units/container_test.rb
@@ -1,0 +1,4 @@
+require 'test_plugin_helper'
+
+class ContainerTest < ActiveSupport::TestCase
+end


### PR DESCRIPTION
When an image cannot be found, the magnifier glass button displays the
search results, including stars, description and a link to the hub.
After the user clicks on an image, tags are auto pulled.
