### PR TITLE
fixes #8716 auto_complete helper now has a unique name.

### DIFF
--- a/app/helpers/containers_helper.rb
+++ b/app/helpers/containers_helper.rb
@@ -47,7 +47,7 @@ module ContainersHelper
     )
   end
 
-  def auto_complete_search(name, val, options = {})
+  def auto_complete_docker_search(name, val, options = {})
     addClass options, 'form-control'
     text_field_tag(name, val, options)
   end

--- a/app/views/containers/steps/image.html.erb
+++ b/app/views/containers/steps/image.html.erb
@@ -26,7 +26,7 @@
             <div class="form-group col-md-6">
               <%= label_tag "image[search]", _('Search'), :class=>"col-sm-2 control-label" %>
               <div class="input-group">
-                <%= auto_complete_search('image[image_id]', '',
+                <%= auto_complete_docker_search('image[image_id]', '',
                                          :'data-url'  => auto_complete_image_container_path(@container),
                                          :value       => f.object.image.present? ? f.object.image.image_id : '',
                                          :id          => :search,


### PR DESCRIPTION
Previous implementation overwrote the helper defined in foreman, which in turn
disabled auto completer for all search fields.
