### PR TITLE
Fixes #8637 - local registry container support

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -13,9 +13,15 @@ class Container < ActiveRecord::Base
                   :cpu_set, :cpu_shares, :memory, :tty, :attach_stdin, :registry_id,
                   :attach_stdout, :attach_stderr, :tag, :uuid, :environment_variables_attributes
 
+  def repository_pull_url
+    repo = tag.blank? ? repository_name : "#{repository_name}:#{tag}"
+    repo = registry.prefixed_url(repo) if registry
+    repo
+  end
+
   def parametrize
     { 'name'  => name, # key has to be lower case to be picked up by the Docker API
-      'Image' => tag.blank? ? repository_name : "#{repository_name}:#{tag}",
+      'Image' => repository_pull_url,
       'Tty'          => tty,                    'Memory'       => memory,
       'Entrypoint'   => entrypoint.try(:split), 'Cmd'          => command.try(:split),
       'AttachStdout' => attach_stdout,          'AttachStdin'  => attach_stdin,

--- a/app/models/docker_registry.rb
+++ b/app/models/docker_registry.rb
@@ -18,4 +18,9 @@ class DockerRegistry < ActiveRecord::Base
         'taxable_taxonomies.taxable_type' => 'DockerRegistry',
         'taxable_taxonomies.taxable_id' => id).pluck(:id)
   end
+
+  def prefixed_url(image_name)
+    uri = URI(url)
+    "#{uri.hostname}:#{uri.port}/#{image_name}"
+  end
 end


### PR DESCRIPTION
Prior to this commit, one could not start containers connected to a
local or non docker hub external registry. This is because the container
parametrize call did not properly prefix the registry url in its Image name.
This commit fixes that.
