### PR TITLE
refs #8963 - Renaming truncs to trunc with tool tips

### DIFF
--- a/app/views/containers/_list.html.erb
+++ b/app/views/containers/_list.html.erb
@@ -18,8 +18,8 @@
       <td class="ellipsis text-center"><%= link_to_container(container, resource) %></td>
       <td class="hidden-tablet hidden-xs text-center">
         <span <%= vm_power_class(container.ready?) %>><%= vm_state(container) %></span></td>
-      <td class="hidden-tablet hidden-xs text-center"><%= trunc(container.image_friendly_name) %></td>
-      <td class="hidden-tablet hidden-xs text-center"><%= trunc(container.command) %></td>
+      <td class="hidden-tablet hidden-xs text-center"><%= trunc_with_tooltip(container.image_friendly_name) %></td>
+      <td class="hidden-tablet hidden-xs text-center"><%= trunc_with_tooltip(container.command) %></td>
       <td class="hidden-tablet hidden-xs text-center">
         <span class="glyphicon glyphicon-time"></span> <%= container.ready? ? time_ago_in_words(container.started_at) : "N/A" %>
       </td>

--- a/app/views/containers/show.html.erb
+++ b/app/views/containers/show.html.erb
@@ -29,7 +29,7 @@
             </tr>
             <tr>
               <td><%= _('UUID') %></td>
-              <td><%= trunc @container.in_fog.identity %></td>
+              <td><%= trunc_with_tooltip @container.in_fog.identity %></td>
             </tr>
             <tr>
               <td><%= _('Memory') %></td>

--- a/app/views/image_search/_repository_search_results.html.erb
+++ b/app/views/image_search/_repository_search_results.html.erb
@@ -6,7 +6,7 @@
       <span class="glyphicon glyphicon-star"></span> <%= repository['star_count'] %>
     </p>
     <p>
-      <%= trunc(repository['description']) %>
+      <%= trunc_with_tooltip(repository['description']) %>
       <%= link_to '<span class="glyphicon glyphicon-share"></span>'.html_safe, hub_url(repository), :target => '_blank' %>
     </p>
 <% end %>

--- a/app/views/registries/index.html.erb
+++ b/app/views/registries/index.html.erb
@@ -17,9 +17,9 @@
 
   <% @registries.each do |r| %>
       <tr>
-        <td><%= link_to_if_authorized trunc(r.name), hash_for_edit_registry_path(:id => r).merge(:auth_object => r, :authorizer => authorizer) %></td>
-        <td class="hidden-tablet hidden-xs text-center"><%= trunc(r.url) %></td>
-        <td class="hidden-tablet hidden-xs text-center"><%= trunc(r.description) %></td>
+        <td><%= link_to_if_authorized trunc_with_tooltip(r.name), hash_for_edit_registry_path(:id => r).merge(:auth_object => r, :authorizer => authorizer) %></td>
+        <td class="hidden-tablet hidden-xs text-center"><%= trunc_with_tooltip(r.url) %></td>
+        <td class="hidden-tablet hidden-xs text-center"><%= trunc_with_tooltip(r.description) %></td>
         <td><%= display_delete_if_authorized hash_for_registry_path(:id => r).merge(:auth_object => r, :authorizer => authorizer), :confirm => _("Delete %s?") % r.name %></td>
       </tr>
   <% end %>


### PR DESCRIPTION
In upstream foreman the trunc method got renamed to trunc with tooltip.
This causes issues with foreman docker when viewing a bunch of index pages
updated all the pages using the trunc method


Check out https://github.com/theforeman/foreman/pull/2087