### PR TITLE
Fixes #9310, #9518 - Create containers using katello repos

### DIFF
--- a/app/controllers/api/v2/containers_controller.rb
+++ b/app/controllers/api/v2/containers_controller.rb
@@ -38,13 +38,16 @@ module Api
           param :name, String, :required => true
           param_group :taxonomies, ::Api::V2::BaseController
           param :compute_resource_id, :identifier, :required => true
-          param :registry_id, :identifier, :desc => N_('Registry this container will have to use
-                                                        to get the image')
-          param :image, String, :desc => N_('Image to use to create the container.
-                                            Format should be repository:tag, e.g: centos:7')
+          param :registry_id, :identifier, :desc => N_('Registry this container will have to
+                                                        use to get the image')
+          param :repository_name, String, :required => true,
+                                          :desc => N_('Name of the repository to use
+                                                       to create the container. e.g: centos')
+          param :tag, String, :required => true,
+                              :desc => N_('Tag to use to create the container. e.g: latest')
           param :tty, :bool
           param :entrypoint, String
-          param :cmd, String
+          param :command, String, :required => true
           param :memory, String
           param :cpu_shares, :number
           param :cpu_sets, String
@@ -52,7 +55,9 @@ module Api
           param :attach_stdout, :bool
           param :attach_stdin, :bool
           param :attach_stderr, :bool
-          param :katello, :bool
+          param :capsule_id, :identifier, :desc => N_('The capsule this container will have to use
+                                                       to get the image. Relevant for images
+                                                       retrieved from katello registry.')
         end
       end
 
@@ -123,14 +128,20 @@ module Api
 
       private
 
-      def set_wizard_state
-        wizard_properties = { :preliminary   => [:compute_resource_id],
-                              :image         => [:registry_id, :repository_name, :tag, :katello],
-                              :configuration => [:name, :command, :entrypoint, :cpu_set,
-                                                 :cpu_shares, :memory],
-                              :environment   => [:tty, :attach_stdin, :attach_stdout,
-                                                 :attach_stderr] }
+      def wizard_properties
+        wizard_props = { :preliminary => [:compute_resource_id],
+                         :image => [:registry_id, :repository_name, :tag],
+                         :configuration => [:name, :command, :entrypoint, :cpu_set,
+                                            :cpu_shares, :memory],
+                         :environment => [:tty, :attach_stdin, :attach_stdout,
+                                          :attach_stderr] }
+        if DockerContainerWizardStates::Image.attribute_names.include?("capsule_id")
+          wizard_props[:image] << :capsule_id
+        end
+        wizard_props
+      end
 
+      def set_wizard_state
         wizard_state = DockerContainerWizardState.create
         wizard_properties.each do |step, properties|
           property_values = properties.each_with_object({}) do |property, values|

--- a/app/models/docker_container_wizard_state.rb
+++ b/app/models/docker_container_wizard_state.rb
@@ -15,7 +15,6 @@ class DockerContainerWizardState < ActiveRecord::Base
     { :repository_name     => image.repository_name,
       :tag                 => image.tag,
       :registry_id         => image.registry_id,
-      :katello             => image.katello?,
       :name                => configuration.name,
       :compute_resource_id => preliminary.compute_resource_id,
       :tty                 => environment.tty,

--- a/db/migrate/20150303175646_remove_katello_flag_from_containers.rb
+++ b/db/migrate/20150303175646_remove_katello_flag_from_containers.rb
@@ -1,0 +1,9 @@
+class RemoveKatelloFlagFromContainers < ActiveRecord::Migration
+  def up
+    remove_column :containers, :katello
+  end
+
+  def down
+    add_column :containers, :katello, :boolean
+  end
+end

--- a/test/functionals/api/v2/containers_controller_test.rb
+++ b/test/functionals/api/v2/containers_controller_test.rb
@@ -12,6 +12,8 @@ module Api
       context 'container operations' do
         setup do
           @container = FactoryGirl.create(:container, :name => 'foo')
+          @registry = FactoryGirl.create(:docker_registry)
+          @compute_resource = FactoryGirl.create(:docker_cr)
         end
 
         test 'logs returns latest lines of container log' do
@@ -59,9 +61,53 @@ module Api
         end
 
         test 'creates a container with correct params' do
+          repository_name = "centos"
+          tag = "7"
+          name = "foo"
+          registry_uri = URI.parse(@registry.url)
           Service::Containers.any_instance.expects(:pull_image).returns(true)
-          Service::Containers.any_instance.expects(:start_container).returns(true)
-          post :create, :container => { :name => 'foo', :registry_id => 3, :image => 'centos:7' }
+          Service::Containers.any_instance
+            .expects(:start_container).returns(true).with do |container|
+            container.must_be_kind_of(Container)
+            container.repository_name.must_equal(repository_name)
+            container.tag.must_equal(tag)
+            container.compute_resource_id.must_equal(@compute_resource.id)
+            container.name.must_equal(name)
+            container.repository_pull_url.must_include(registry_uri.host)
+            container.repository_pull_url.must_include("#{repository_name}:#{tag}")
+          end
+          post :create, :container => { :compute_resource_id => @compute_resource.id,
+                                        :name => name,
+                                        :registry_id => @registry.id,
+                                        :repository_name => repository_name,
+                                        :tag => tag }
+          assert_response :created
+        end
+
+        test 'creates a katello container with correct params' do
+          DockerContainerWizardStates::Image.class_eval do
+            attr_accessor :capsule_id
+          end
+          DockerContainerWizardStates::Image.attribute_names.stubs(:include?).returns(true)
+          repository_name = "katello_centos"
+          tag = "7"
+          name = "foo"
+          capsule_id = "10000"
+          Service::Containers.any_instance.expects(:start_container!)
+            .returns(@container).with do |wizard_state|
+            wizard_state.must_be_kind_of(DockerContainerWizardState)
+            container_attributes = wizard_state.container_attributes
+            container_attributes[:repository_name].must_equal(repository_name)
+            container_attributes[:tag].must_equal(tag)
+            container_attributes[:compute_resource_id].must_equal(@compute_resource.id)
+            container_attributes[:name].must_equal(name)
+            wizard_state.image.capsule_id.must_equal(capsule_id)
+          end
+          post :create, :container => { :compute_resource_id => @compute_resource.id,
+                                        :name => name,
+                                        :capsule_id => capsule_id,
+                                        :repository_name => repository_name,
+                                        :tag => tag }
           assert_response :created
         end
       end


### PR DESCRIPTION
This commit adds code to create Containers using katello repos. Ties with 
https://github.com/Katello/katello/pull/5077 and https://github.com/Katello/hammer-cli-katello/pull/281 .

Usage
```bash
$ hammer repository list --content-type=docker --organization-id=1 --content-view=cv --environment dev
---|------------------------------------------------------------|--------------------------|--------------|----
ID | NAME                                                       | PRODUCT                  | CONTENT TYPE | URL
---|------------------------------------------------------------|--------------------------|--------------|----
8  | CENTOS                                                     | great                    | docker       |    
---|------------------------------------------------------------|--------------------------|--------------|----

$ hammer repository info --id=8
....
ID:                   8
Name:                 CENTOS
... <snip>....
Container Image Name: default_organization-dev-cv-centos-great-centos
...<snip>....

$ hammer docker tag list --repository-id=8
---|-----|--------------
ID | TAG   | REPOSITORY ID
---|---------|--------------
51 | latest  | 8            
.....<snip>....

Finally :) ....


$  hammer docker container create --name=fooo --repository-name="default_organization-dev-cv-centos-great-centos" --tag="latest" --compute-resource-id=3  --command="/bin/bash"

Docker Container Created.
```

Drum roll....