### PR TITLE
Fixes #9897 - Stub encryption key in registry test

### DIFF
--- a/test/units/docker_registry_test.rb
+++ b/test/units/docker_registry_test.rb
@@ -18,7 +18,9 @@ class DockerRegistryTest < ActiveSupport::TestCase
   end
 
   test 'password is stored encrypted' do
-    registry = as_admin { FactoryGirl.create(:docker_registry) }
+    registry = as_admin { FactoryGirl.build(:docker_registry) }
+    registry.password = 'encrypted-whatever'
+    DockerRegistry.any_instance.expects(:encryption_key).at_least_once.returns('fakeencryptionkey')
     assert registry.is_decryptable?(registry.password_in_db)
   end
 


### PR DESCRIPTION
Currently CI is broken as it needs the encryption key to be set. In the
past core provided a key for the Rails test environment but that's no
longer the case