### PR TITLE
Fixes #7865 - Adds support for configuring dns during container creation

### DIFF
--- a/app/models/docker_container_wizard_state.rb
+++ b/app/models/docker_container_wizard_state.rb
@@ -11,6 +11,7 @@ class DockerContainerWizardState < ActiveRecord::Base
   delegate :compute_resource_id,   :to => :preliminary
   delegate :environment_variables, :to => :environment
   delegate :exposed_ports, :to => :environment
+  delegate :dns, :to => :environment
 
   def container_attributes
     { :repository_name     => image.repository_name,

--- a/app/models/docker_container_wizard_states/dns.rb
+++ b/app/models/docker_container_wizard_states/dns.rb
@@ -1,0 +1,18 @@
+module DockerContainerWizardStates
+  class Dns < Parameter
+    # The Parameter class from which this Dns class inherits,validates for the
+    # presence of an associated domain,  operating system, host or host group.
+    # We will have to reset those validations for the Dns class as they do not
+    # make any sense for the context in which this class is being used here.
+    Dns.reset_callbacks(:validate)
+
+    belongs_to :environment,  :foreign_key => :reference_id,
+                              :inverse_of => :dns,
+                              :class_name => 'DockerContainerWizardStates::Environment'
+    validates :name, :uniqueness => { :scope => :reference_id },
+                     :format => {
+                       :with => Regexp.union(Resolv::IPv4::Regex,
+                                             Resolv::IPv6::Regex,
+                                             /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}$/) }
+  end
+end

--- a/app/models/docker_container_wizard_states/environment.rb
+++ b/app/models/docker_container_wizard_states/environment.rb
@@ -17,9 +17,14 @@ module DockerContainerWizardStates
                               :inverse_of => :environment,
                               :class_name => 'DockerContainerWizardStates::ExposedPort',
                               :validate => true
+    has_many :dns,  :dependent  => :destroy, :foreign_key => :reference_id,
+                    :inverse_of => :environment,
+                    :class_name => 'DockerContainerWizardStates::Dns',
+                    :validate => true
 
     accepts_nested_attributes_for :environment_variables, :allow_destroy => true
     accepts_nested_attributes_for :exposed_ports, :allow_destroy => true
+    accepts_nested_attributes_for :dns, :allow_destroy => true
 
     def parameters_symbol
       :environment_variables

--- a/app/models/foreman_docker/dns.rb
+++ b/app/models/foreman_docker/dns.rb
@@ -1,0 +1,20 @@
+module ForemanDocker
+  class Dns < Parameter
+    # The Parameter class from which this Dns class inherits,validates for the
+    # presence of an associated domain,  operating system, host or host group.
+    # We will have to reset those validations for the Dns class as they do not
+    # make any sense for the context in which this class is being used here.
+    ForemanDocker::Dns.reset_callbacks(:validate)
+
+    belongs_to :container, :foreign_key => :reference_id,
+                           :inverse_of => :dns,
+                           :class_name => "Container"
+
+    audited :except => [:priority], :associated_with => :container, :allow_mass_assignment => true
+    validates :name, :uniqueness => { :scope => :reference_id },
+                     :format => {
+                       :with => Regexp.union(Resolv::IPv4::Regex,
+                                             Resolv::IPv6::Regex,
+                                             /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}$/) }
+  end
+end

--- a/app/models/service/containers.rb
+++ b/app/models/service/containers.rb
@@ -13,6 +13,7 @@ module Service
 
           load_environment_variables(state, r)
           load_exposed_ports(state, r)
+          load_dns(state, r)
         end
 
         Taxonomy.enabled_taxonomies.each do |taxonomy|
@@ -59,6 +60,13 @@ module Service
         r.exposed_ports.build :name => e.name,
                               :value => e.value,
                               :priority => e.priority
+      end
+    end
+
+    def load_dns(state, r)
+      state.dns.each do |e|
+        r.dns.build :name => e.name,
+                    :priority => e.priority
       end
     end
   end

--- a/app/views/containers/show.html.erb
+++ b/app/views/containers/show.html.erb
@@ -54,6 +54,14 @@
               </td>
             </tr>
             <tr>
+              <td><%= _('DNS') %></td>
+              <td>
+                  <% (@container.in_fog.attributes['host_config_dns'] || []).each do |dns| %>
+                    <%= dns %><br/>
+                  <% end %>
+                </td>
+            </tr>            
+            <tr>
               <td><%= _('Environment Variables') %></td>
               <td>
                 <table id="environment_variables" class="table table-bordered" style="table-layout:fixed; word-wrap: break-word">

--- a/app/views/containers/steps/environment.html.erb
+++ b/app/views/containers/steps/environment.html.erb
@@ -22,6 +22,12 @@
         <% end %>
         <%= link_to_add_fields(_("Add Exposed Port"), f, :exposed_ports,
                                'foreman_docker/common_parameters/exposed_ports') %>
+        <h3><%= _("DNS") %></h3>
+        <%= f.fields_for :dns, @docker_container_wizard_states_environment.dns do |builder| %>
+          <%= render 'foreman_docker/common_parameters/dns', :f => builder %>
+        <% end %>
+        <%= link_to_add_fields(_("Add DNS"), f, :dns,
+                               'foreman_docker/common_parameters/dns') %>                               
       </div>
    </div>
    <%= render :partial => 'form_buttons' %>

--- a/app/views/foreman_docker/common_parameters/_dns.erb
+++ b/app/views/foreman_docker/common_parameters/_dns.erb
@@ -1,0 +1,16 @@
+<div class='fields'>
+  <table class="table table-bordered table-hover table-striped">
+    <tr class="form-group <%= 'has-error' if f.object.errors.any? %>">
+      <td><%= f.text_field(:name,  :class => "form-control",
+                                   :placeholder => _("DNS e.g: 8.8.8.8")) %></td>
+      <td style='vertical-align: middle' class='text-center'>
+        <span class="help-block">
+          <%= link_to_remove_fields('', f) %>
+        </span>
+      </td>
+      <span class="help-block">
+        <%= f.object.errors.full_messages.to_sentence %>
+      </span>
+    </tr>
+  </table>
+</div>


### PR DESCRIPTION
Please review this commit which adds support for configuring DNS.

This can be merged **without** upgrading `Fog`. 
I am accessing the DNS entries by accessing it through the collection of all `attributes` that come bundled with `@container.in_fog` (pretty much the same way `config_env` is being accessed). After my pull request to `Fog` gets through, we would be able to access `:dns` variables using something like `@container.in_fog.dns` instead of `@container.in_fog.attributes['host_config_dns']`

I am still struggling with the tests. I will write the tests and push a new commit on this pull request soon. 