### PR TITLE
Fixes #9311 - Renamed Katello tab in the containers page

### DIFF
--- a/app/views/containers/steps/image.html.erb
+++ b/app/views/containers/steps/image.html.erb
@@ -6,7 +6,7 @@
       <% if defined? Katello -%>
         <li class="<%= tab_class(:katello)%>"><a href="#katello" data-toggle="tab" id="katello_tab">
           <span class="glyphicon glyphicon-tower"></span>
-          <%= _("Katello") %>
+          <%= _("Content View") %>
         </a></li>
       <% end -%>
 


### PR DESCRIPTION
It makes more sense to say Provision a container using contnet from
'this' content view as opposed to content from katello. This commit changes the name of
header to match that.