### PR TITLE
Fixes #10404 - Finds correct repo name for Docker Hub registry

### DIFF
--- a/app/controllers/image_search_controller.rb
+++ b/app/controllers/image_search_controller.rb
@@ -60,7 +60,15 @@ class ImageSearchController < ::ApplicationController
   end
 
   def hub_search_image(terms)
-    @compute_resource.search(terms)
+    @compute_resource.search(terms).map do |item|
+      # el7 returns -> "name" => "docker.io: docker.io/centos",
+      # while f20 returns -> "name" => "centos"
+      # we need repo name to be => "docker.io/centos" for el7 and "centos" for fedora
+      # to ensure proper search with respect to the tags, image creation etc.
+      new_item = item.clone
+      new_item["name"] = item["name"].split.last
+      new_item
+    end
   end
 
   def registry_image_exists?(term)

--- a/app/helpers/containers_helper.rb
+++ b/app/helpers/containers_helper.rb
@@ -77,14 +77,6 @@ module ContainersHelper
     text_field_tag(name, val, options)
   end
 
-  def hub_url(image)
-    if image['is_official']
-      "https://registry.hub.docker.com/_/#{image['name']}"
-    else
-      "https://registry.hub.docker.com/u/#{image['name']}"
-    end
-  end
-
   # Compatibility fixes - to be removed once 1.7 compatibility is no longer required
   if SETTINGS[:version].to_s.to_f <= 1.7
     def trunc_with_tooltip(text, length = 32)

--- a/app/views/image_search/_repository_search_results.html.erb
+++ b/app/views/image_search/_repository_search_results.html.erb
@@ -7,6 +7,5 @@
     </p>
     <p>
       <%= trunc_with_tooltip(repository['description']) %>
-      <%= link_to '<span class="glyphicon glyphicon-share"></span>'.html_safe, hub_url(repository), :target => '_blank' %>
     </p>
 <% end %>

--- a/test/functionals/image_search_controller_test.rb
+++ b/test/functionals/image_search_controller_test.rb
@@ -26,6 +26,40 @@ class ImageSearchControllerTest < ActionController::TestCase
     end
   end
 
+  test "centos 7 search responses are handled correctly" do
+    repository = "registry-fancycorp.rhcloud.com/fancydb-rhel7/fancydb"
+    repo_full_name = "redhat.com: #{repository}"
+    request.env["HTTP_ACCEPT"] = "application/javascript"
+    expected = [{  "description" => "Really fancy database app...",
+                   "is_official" => true,
+                   "is_trusted" => true,
+                   "name" =>  repo_full_name,
+                   "star_count" => 0
+                }]
+    ForemanDocker::Docker.any_instance.expects(:search).returns(expected).at_least_once
+    get :search_repository, { :search => "centos", :id => @container.id }, set_session_user
+    assert_response :success
+    refute response.body.include?(repo_full_name)
+    assert response.body.include?(repository)
+  end
+
+  test "fedora search responses are handled correctly" do
+    repository = "registry-fancycorp.rhcloud.com/fancydb-rhel7/fancydb"
+    repo_full_name = repository
+    request.env["HTTP_ACCEPT"] = "application/javascript"
+    expected = [{ "description" => "Really fancy database app...",
+                  "is_official" => true,
+                  "is_trusted" => true,
+                  "name" =>  repo_full_name,
+                  "star_count" => 0
+                }]
+    ForemanDocker::Docker.any_instance.expects(:search).returns(expected).at_least_once
+    get :search_repository, { :search => "centos", :id => @container.id }, set_session_user
+    assert_response :success
+    assert response.body.include?(repo_full_name)
+    assert response.body.include?(repository)
+  end
+
   def assert_response_is_expected
     assert_response :error
     assert response.body.include?('An error occured during repository search:')


### PR DESCRIPTION
Bug is stated as follows
on centos 7 ->

$ docker version
Client version: 1.5.0-dev
Client API version: 1.18
Go version (client): go1.3.3

$ docker search centos
NAME DESCRIPTION STARS OFFICIAL AUTOMATED
docker.io: docker.io/centos The official build of CentOS. 978 [OK]
docker.io: docker.io/ansible/centos7-ansible Ansible on Centos7 40 [OK]
.....

On fedora 20 ->
$ docker version
Client version: 1.5.0
Client API version: 1.17

$ docker search centos
NAME DESCRIPTION STARS OFFICIAL AUTOMATED
centos The official build of CentOS. 978 [OK]
ansible/centos7-ansible Ansible on Centos7 40 [OK]
......

Note the "docker.io: " prefix for the centos 7 name columns
http://rhelblog.redhat.com/2015/04/15/understanding-the-changes-to-docker-search-and-docker-pull-in-red-hat-enterprise-linux-7-1/
has details on why thats the case.

When you ask foreman-docker "search centos from docker hub", it gives
you different names based on whether the docker compute resource is
running on el7 or fedora 20. You then select an image and it shows the
tags for that. Based on your selections it picks "NAME" as the repo name
and chooses the tag. This works for docker compute instance running on
f20 and used to work for docker instance on el7.

Anyway problem is simple -> "docker.io: docker.io/centos" is not a valid
repo name. So foreman-docker has to somehow infer that
"docker.io/centos" is what the repo name should be and strip out
"docker.io: " while it should some how also work for
"my-other-registry.com:4000/cool-repo" and not strip out
"my-other-registry.com:4000".

This commit achieves to do that.