### PR TITLE
Fixes #10779 - Error messages hidden after wizard

### DIFF
--- a/app/controllers/containers/steps_controller.rb
+++ b/app/controllers/containers/steps_controller.rb
@@ -58,7 +58,7 @@ module Containers
       else
         @docker_container_wizard_states_environment = @state.environment
         process_error(
-            :error_msg => service.errors,
+            :error_msg => service.errors.full_messages.join(','),
             :object => @state.environment,
             :render => 'environment')
       end


### PR DESCRIPTION
Reproduce by creating two containers with the same name, you'll see the alert displayed won't show the actual error but just the internal object.