### PR TITLE
Fixes #11354 - Made the container deal with cpu shares correctly

### DIFF
--- a/db/migrate/20150814205620_change_container_column_type.rb
+++ b/db/migrate/20150814205620_change_container_column_type.rb
@@ -1,0 +1,13 @@
+class ChangeContainerColumnType < ActiveRecord::Migration
+  def up
+    change_column :containers, :cpu_shares, :integer
+    change_column :docker_container_wizard_states_configurations, :cpu_shares, :integer
+    change_column :docker_container_wizard_states_configurations, :cpu_set, :string
+  end
+
+  def down
+    change_column :containers, :cpu_shares, :float
+    change_column :docker_container_wizard_states_configurations, :cpu_shares, :float
+    change_column :docker_container_wizard_states_configurations, :cpu_set, :integer
+  end
+end


### PR DESCRIPTION
According to docker remote api 'cpu shares' need to be integers.
However foreman docker sends it a float instead causing a
'cant convert to int64' error. This commit fixes that by ensuring what gets sent
to the container is an integer