### PR TITLE
Fixes #12785 - Raise requires_foreman version to 1.11

### DIFF
--- a/lib/foreman_docker/engine.rb
+++ b/lib/foreman_docker/engine.rb
@@ -41,7 +41,7 @@ module ForemanDocker
 
     initializer 'foreman_docker.register_plugin', :after => :finisher_hook do
       Foreman::Plugin.register :foreman_docker do
-        requires_foreman '> 1.4'
+        requires_foreman '>= 1.11'
         compute_resource ForemanDocker::Docker
 
         sub_menu :top_menu, :containers_menu, :caption => N_('Containers'),


### PR DESCRIPTION
Since now we use attr_accessible, and more changes are coming up to make
this plugin Rails 4 compatible, the minimum version needs to be 1.11.