### PR TITLE
Fixes #14181 - Validate registry URL and attempt login

### DIFF
--- a/app/views/registries/index.html.erb
+++ b/app/views/registries/index.html.erb
@@ -11,7 +11,7 @@
     <th class="text-center"><%= sort :name, :as => _("Name") %></th>
     <th class="hidden-tablet hidden-xs text-center"><%= sort :url, :as => _("Url") %></th>
     <th class="hidden-tablet hidden-xs text-center"><%= _("Description") %></th>
-    <th></th>
+    <th><%= _('Actions') %></th>
   </tr>
   </thead>
 
@@ -20,7 +20,10 @@
         <td><%= link_to_if_authorized trunc_with_tooltip(r.name), hash_for_edit_registry_path(:id => r).merge(:auth_object => r, :authorizer => authorizer) %></td>
         <td class="hidden-tablet hidden-xs text-center"><%= trunc_with_tooltip(r.url) %></td>
         <td class="hidden-tablet hidden-xs text-center"><%= trunc_with_tooltip(r.description) %></td>
-        <td><%= display_delete_if_authorized hash_for_registry_path(:id => r).merge(:auth_object => r, :authorizer => authorizer), :confirm => _("Delete %s?") % r.name %></td>
+        <td><%= action_buttons(
+          display_delete_if_authorized hash_for_registry_path(:id => r).
+          merge(:auth_object => r, :authorizer => authorizer),
+          :confirm => _("Delete %s?") % r.name) %></td>
       </tr>
   <% end %>
 </table>

--- a/test/factories/docker_registry.rb
+++ b/test/factories/docker_registry.rb
@@ -6,6 +6,10 @@ FactoryGirl.define do
     sequence(:password) { |n| "password#{n}" }
   end
 
+  after(:build) do |registry|
+    registry.stubs(:attempt_login)
+  end
+
   trait :with_location do
     locations { [FactoryGirl.build(:location)] }
   end

--- a/test/functionals/api/v2/registries_controller_test.rb
+++ b/test/functionals/api/v2/registries_controller_test.rb
@@ -24,6 +24,7 @@ module Api
 
       test 'creates a new registry with valid params' do
         docker_attrs = FactoryGirl.attributes_for(:docker_registry)
+        DockerRegistry.any_instance.stubs(:attempt_login)
         post :create, :registry => docker_attrs
         assert_response :success
       end
@@ -41,6 +42,7 @@ module Api
       end
 
       test 'update a docker registry' do
+        DockerRegistry.any_instance.stubs(:attempt_login)
         put :update, :id => @registry.id, :registry => { :name => 'hello_world' }
         assert_response :success
         assert DockerRegistry.exists?(:name => 'hello_world')


### PR DESCRIPTION
In order to avoid users trying to create containers in an external
registry that doesn't exist, we should provide some preventative
measures.