### PR TITLE
Fixes #14370 - Adapt containers and registries index to core 1.12

### DIFF
--- a/app/views/containers/index.html.erb
+++ b/app/views/containers/index.html.erb
@@ -1,9 +1,6 @@
 <% title _("Containers") %>
 
-<% if authorized? %>
-  <% title_actions button_group(link_to_if_authorized _("New container"), hash_for_new_container_path,
-                                                      :class => 'btn-success') %>
-<% end %>
+<%= title_actions(new_link(_("New container"))) %>
 
 <ul class="nav nav-tabs" data-tabs="tabs">
   <% @container_resources.each_with_index do |resource, i| %>

--- a/app/views/registries/index.html.erb
+++ b/app/views/registries/index.html.erb
@@ -1,9 +1,6 @@
 <% title _("Registries") %>
 
-<% if authorized? %>
-    <% title_actions button_group(link_to_if_authorized _("New Registry"), hash_for_new_registry_path,
-                                                        :class => 'btn-success' ) %>
-<% end %>
+<%= title_actions(new_link(_("New registry"))) %>
 
 <table class="table table-bordered table-striped table-condensed" data-table="inline">
   </thead>


### PR DESCRIPTION
`authorized?` is no longer available, and there's a helper for the "New
xxxxx" buttons