### PR TITLE
Refs #14181 - Fix authentication validation when creating registry

### DIFF
--- a/app/models/docker_registry.rb
+++ b/app/models/docker_registry.rb
@@ -42,11 +42,10 @@ class DockerRegistry < ActiveRecord::Base
   private
 
   def attempt_login
-    credentials = { 'username' => username, 'password' => password }
-    connection = ::Docker::Connection.new(
-      url,
-      credentials)
-    ::Docker.authenticate!(credentials, connection)
+    login_endpoint = RestClient::Resource.new(url + '/v1/users',
+                                              :user => username,
+                                              :password => password)
+    login_endpoint.get == "\"OK\""
   rescue => e
     errors.add(:base, _('Unable to log in to this Docker Registry - %s') % e)
   end

--- a/foreman_docker.gemspec
+++ b/foreman_docker.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*', '.rubocop.yml']
 
-  s.add_dependency 'docker-api', '1.17'
+  s.add_dependency 'docker-api', '~> 1.17'
   s.add_dependency 'wicked', '~> 1.1'
 end

--- a/test/units/docker_registry_test.rb
+++ b/test/units/docker_registry_test.rb
@@ -36,12 +36,12 @@ class DockerRegistryTest < ActiveSupport::TestCase
     end
 
     test 'before creating a registry' do
-      ::Docker.expects(:authenticate!)
+      RestClient::Resource.any_instance.expects(:get)
       assert @registry.valid?
     end
 
     test 'display errors in case authentication failed' do
-      ::Docker.expects(:authenticate!).
+      RestClient::Resource.any_instance.expects(:get).
         raises(Docker::Error::AuthenticationError)
       refute @registry.valid?
     end


### PR DESCRIPTION
On 9ea405911cef1f02ca42db77c16bea4fe297093e Docker.authenticate! was
calling /auth on the Docker host API. This kind of authentication was
not correct, as it was authenticating access to the Docker host, not to
the registry.

Instead, we just perform a restclient call with basic authentication
against an endpoint as per https://docs.docker.com/v1.7/reference/api/hub_registry_spec/#authentication-and-authorization

We should support token authentication as well after this and add a
new field to the form.

Feel free to test with registry.access.redhat.com or https://registry.hub.docker.com/ - the latter will ask for username password, the former would work with anything.