### PR TITLE
Fixes #7894 - Compute resource should show 'containers' tab

### DIFF
--- a/app/overrides/rename_virtual_machines_containers.rb
+++ b/app/overrides/rename_virtual_machines_containers.rb
@@ -1,0 +1,10 @@
+Deface::Override.new(
+  :virtual_path => 'compute_resources/show',
+  :name => 'rename_virtual_machines_containers',
+  :replace => "erb[loud]:contains('Virtual Machines')",
+  :text => "<%= if @compute_resource.type == 'ForemanDocker::Docker'
+                  _('Containers')
+                else
+                  _('Virtual Machines')
+                end %>"
+)

--- a/foreman_docker.gemspec
+++ b/foreman_docker.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*', '.rubocop.yml']
 
   s.add_dependency 'docker-api', '~> 1.17'
+  s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'wicked', '~> 1.1'
 end

--- a/lib/foreman_docker/engine.rb
+++ b/lib/foreman_docker/engine.rb
@@ -3,6 +3,7 @@ require 'gettext_i18n_rails'
 require 'fog/fogdocker'
 require 'wicked'
 require 'docker'
+require 'deface'
 
 module ForemanDocker
   # Inherit from the Rails module of the parent app (Foreman), not the plugin.


### PR DESCRIPTION
Through deface, we change the 'virtual machines' tab to say container on
Docker compute resources.