### PR TITLE
Fixes #10417 - Translate wizard states

### DIFF
--- a/app/helpers/container_steps_helper.rb
+++ b/app/helpers/container_steps_helper.rb
@@ -2,7 +2,7 @@ module ContainerStepsHelper
   def container_wizard(step)
     wizard_header(
       step,
-      *wizard_steps.map { |s| s.to_s.humanize }
+      *humanized_steps
     )
   end
 
@@ -16,6 +16,10 @@ module ContainerStepsHelper
                         { :prompt => _("Select a registry") },
                         :class => "form-control", :disabled => registries.size == 0
     end
+  end
+
+  def humanized_steps
+    [_('Preliminary'), _('Image'), _('Configuration'), _('Environment')]
   end
 
   def last_step?

--- a/locale/de/foreman_docker.po
+++ b/locale/de/foreman_docker.po
@@ -110,6 +110,9 @@ msgstr "Rechenoptionen"
 msgid "Compute resource"
 msgstr "Rechnerressource"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "Container %s wird gelöscht."
 
@@ -182,6 +185,9 @@ msgstr "Unterstützt dieses Image die Eingabe von Benutzerdaten?"
 
 msgid "Edit Registry"
 msgstr "Registry bearbeiten"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "Umgebungsvariablen"
@@ -275,6 +281,9 @@ msgstr "Neue Registry"
 msgid "New container"
 msgstr "Neuer Container"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author jdimanos
 msgid "Next"
 msgstr "Weiter"
@@ -314,6 +323,9 @@ msgstr "Strom"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "System starten"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/es/foreman_docker.po
+++ b/locale/es/foreman_docker.po
@@ -110,6 +110,9 @@ msgstr "Opciones de cómputo"
 msgid "Compute resource"
 msgstr "Recurso de cómputo"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "El contenedor se ha eliminado %s ."
 
@@ -182,6 +185,9 @@ msgstr "¿Esta imagen soporta entrada de datos de usuario?"
 
 msgid "Edit Registry"
 msgstr "Modificar registro"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "Variables de entorno"
@@ -275,6 +281,9 @@ msgstr "Nuevo registro"
 msgid "New container"
 msgstr "Nuevo contenedor"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gguerrer
 msgid "Next"
 msgstr "Siguiente"
@@ -314,6 +323,9 @@ msgstr "Energía"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "Encender esta máquina"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/foreman_docker.pot
+++ b/locale/foreman_docker.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: foreman_docker 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-16 16:35-0400\n"
-"PO-Revision-Date: 2016-03-16 16:35-0400\n"
+"POT-Creation-Date: 2016-03-30 11:55+0200\n"
+"PO-Revision-Date: 2016-03-30 11:55+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -157,13 +157,32 @@ msgstr ""
 msgid "Select a registry"
 msgstr ""
 
+#: ../app/helpers/container_steps_helper.rb:22
+#: ../app/views/compute_resources_vms/form/_docker.html.erb:6
+#: ../app/views/compute_resources_vms/index/_docker.html.erb:5
+#: ../app/views/containers/_list.html.erb:6
+msgid "Image"
+msgstr ""
+
+#: ../app/helpers/container_steps_helper.rb:22
+msgid "Environment"
+msgstr ""
+
+#: ../app/helpers/container_steps_helper.rb:22
+msgid "Configuration"
+msgstr ""
+
+#: ../app/helpers/container_steps_helper.rb:22
+msgid "Preliminary"
+msgstr ""
+
 #: ../app/helpers/containers_helper.rb:34
 msgid "Commit"
 msgstr ""
 
 #: ../app/helpers/containers_helper.rb:43
 #: ../app/views/containers/_list.html.erb:36
-#: ../app/views/registries/index.html.erb:26
+#: ../app/views/registries/index.html.erb:23
 msgid "Delete %s?"
 msgstr ""
 
@@ -183,7 +202,7 @@ msgstr ""
 msgid "Docker/Registry"
 msgstr ""
 
-#: ../app/models/docker_registry.rb:51
+#: ../app/models/docker_registry.rb:50
 msgid "Unable to log in to this Docker Registry - %s"
 msgstr ""
 
@@ -204,14 +223,8 @@ msgid "Test Connection"
 msgstr ""
 
 #: ../app/views/compute_resources/show/_docker.html.erb:2
-#: ../app/views/registries/index.html.erb:12
+#: ../app/views/registries/index.html.erb:9
 msgid "URL"
-msgstr ""
-
-#: ../app/views/compute_resources_vms/form/_docker.html.erb:6
-#: ../app/views/compute_resources_vms/index/_docker.html.erb:5
-#: ../app/views/containers/_list.html.erb:6
-msgid "Image"
 msgstr ""
 
 #: ../app/views/compute_resources_vms/form/_docker.html.erb:10
@@ -245,7 +258,7 @@ msgstr ""
 #: ../app/views/compute_resources_vms/show/_docker.html.erb:6
 #: ../app/views/containers/_list.html.erb:4
 #: ../app/views/containers/show.html.erb:11
-#: ../app/views/registries/index.html.erb:11
+#: ../app/views/registries/index.html.erb:8
 msgid "Name"
 msgstr ""
 
@@ -318,13 +331,13 @@ msgstr ""
 msgid "Containers"
 msgstr ""
 
-#: ../app/views/containers/index.html.erb:4
+#: ../app/views/containers/index.html.erb:3
 #: ../app/views/containers/steps/_title.html.erb:1
 #: ../lib/foreman_docker/engine.rb:52
 msgid "New container"
 msgstr ""
 
-#: ../app/views/containers/index.html.erb:30
+#: ../app/views/containers/index.html.erb:27
 msgid "Error connecting with the compute resource: <strong> %s </strong>"
 msgstr ""
 
@@ -456,11 +469,11 @@ msgid "Shell"
 msgstr ""
 
 #: ../app/views/containers/steps/environment.html.erb:6
-msgid "Allocate a pseudo-tty"
+msgid "TTY"
 msgstr ""
 
 #: ../app/views/containers/steps/environment.html.erb:6
-msgid "TTY"
+msgid "Allocate a pseudo-tty"
 msgstr ""
 
 #: ../app/views/containers/steps/environment.html.erb:7
@@ -598,17 +611,20 @@ msgstr ""
 msgid "Registries"
 msgstr ""
 
-#: ../app/views/registries/index.html.erb:4
-#: ../app/views/registries/new.html.erb:1
-msgid "New Registry"
+#: ../app/views/registries/index.html.erb:3
+msgid "New registry"
 msgstr ""
 
-#: ../app/views/registries/index.html.erb:13
+#: ../app/views/registries/index.html.erb:10
 msgid "Description"
 msgstr ""
 
-#: ../app/views/registries/index.html.erb:14
+#: ../app/views/registries/index.html.erb:11
 msgid "Actions"
+msgstr ""
+
+#: ../app/views/registries/new.html.erb:1
+msgid "New Registry"
 msgstr ""
 
 #: ../lib/foreman_docker/engine.rb:49

--- a/locale/fr/foreman_docker.po
+++ b/locale/fr/foreman_docker.po
@@ -111,6 +111,9 @@ msgstr "Options de calcul"
 msgid "Compute resource"
 msgstr "Ressource de calcul"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "Le Conteneur %s est en cours de suppression."
 
@@ -183,6 +186,9 @@ msgstr "Cette image prend-t-elle en charge l'entrée de paramètres utilisateur�
 
 msgid "Edit Registry"
 msgstr "Modifier le registre"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "Variables d'environnement"
@@ -276,6 +282,9 @@ msgstr "Nouveau registre"
 msgid "New container"
 msgstr "Nouveau conteneur"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author Sam Friedmann
 msgid "Next"
 msgstr "Suivant"
@@ -315,6 +324,9 @@ msgstr "Alimentation"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "Démarrer cette machine"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/it/foreman_docker.po
+++ b/locale/it/foreman_docker.po
@@ -109,6 +109,9 @@ msgstr "Opzioni di calcolo"
 msgid "Compute resource"
 msgstr "Risorsa di calcolo"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "Il container %s è stato cancellato."
 
@@ -181,6 +184,9 @@ msgstr "Questa immagine supporta l'input dei dati utente?"
 
 msgid "Edit Registry"
 msgstr "Modifica registro"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "Variabili dell'ambiente"
@@ -274,6 +280,9 @@ msgstr "Nuovo registro"
 msgid "New container"
 msgstr "Nuovo container"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author fvalen
 msgid "Next"
 msgstr "Avanti"
@@ -313,6 +322,9 @@ msgstr "Alimentazione"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "Attiva questa macchina"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/ja/foreman_docker.po
+++ b/locale/ja/foreman_docker.po
@@ -112,6 +112,9 @@ msgstr "コンピュートオプション"
 msgid "Compute resource"
 msgstr "コンピュートリソース"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "コンテナー %s が削除されています。"
 
@@ -185,6 +188,9 @@ msgstr "このイメージはユーザーのデータ入力に対応しますか
 
 msgid "Edit Registry"
 msgstr "レジストリーの編集"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "環境変数"
@@ -278,6 +284,9 @@ msgstr "新規レジストリー"
 msgid "New container"
 msgstr "新規コンテナー"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author asasaki
 msgid "Next"
 msgstr "次へ"
@@ -317,6 +326,9 @@ msgstr "パワー"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "このマシンのパワーをオンにする"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/ko/foreman_docker.po
+++ b/locale/ko/foreman_docker.po
@@ -109,6 +109,9 @@ msgstr "컴퓨팅 옵션 "
 msgid "Compute resource"
 msgstr "컴퓨터 리소스 "
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "컨테이너 %s이(가) 삭제되어 있습니다. "
 
@@ -181,6 +184,9 @@ msgstr "이 이미지는 사용자 데이터 입력을 지원하고 있습니까
 
 msgid "Edit Registry"
 msgstr "레지스트리 편집 "
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "환경 변수 "
@@ -274,6 +280,9 @@ msgstr "새 레지스트리 "
 msgid "New container"
 msgstr "새 컨테이너 "
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author eukim
 msgid "Next"
 msgstr "다음"
@@ -313,6 +322,9 @@ msgstr "전원"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "컴퓨터의 전원 켜기 "
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/pt_BR/foreman_docker.po
+++ b/locale/pt_BR/foreman_docker.po
@@ -110,6 +110,9 @@ msgstr "Opções computadas"
 msgid "Compute resource"
 msgstr "Recurso de computação"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "Container %s está sendo excluído. "
 
@@ -182,6 +185,9 @@ msgstr "Esta imagem suporta a entrada de dados do usuário?"
 
 msgid "Edit Registry"
 msgstr "Editar um Registro"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "Variáveis de Ambiente"
@@ -275,6 +281,9 @@ msgstr "Novo Registro"
 msgid "New container"
 msgstr "Novo container"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author gcintra
 msgid "Next"
 msgstr "Próximo"
@@ -314,6 +323,9 @@ msgstr "Energia"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "Ligar essa máquina"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/ru/foreman_docker.po
+++ b/locale/ru/foreman_docker.po
@@ -110,6 +110,9 @@ msgstr "Вычислительные параметры"
 msgid "Compute resource"
 msgstr "Ресурс"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "Удаление контейнера %s..."
 
@@ -182,6 +185,9 @@ msgstr "Допускает ли этот образ ввод пользоват�
 
 msgid "Edit Registry"
 msgstr "Изменение реестра"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "Переменные окружения"
@@ -275,6 +281,9 @@ msgstr "Добавить"
 msgid "New container"
 msgstr "Новый контейнер"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project Customer Portal Translations, version Portal-Case-Management, document Template, author ypoyarko
 msgid "Next"
 msgstr "Вперед"
@@ -314,6 +323,9 @@ msgstr "Питание"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "Включить машину"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/zh_CN/foreman_docker.po
+++ b/locale/zh_CN/foreman_docker.po
@@ -109,6 +109,9 @@ msgstr "计算选项"
 msgid "Compute resource"
 msgstr "计算机资源"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "要删除容器 %s。"
 
@@ -181,6 +184,9 @@ msgstr "这个映像是否支持用户数据输入？"
 
 msgid "Edit Registry"
 msgstr "编辑注册"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "环境变量"
@@ -274,6 +280,9 @@ msgstr "新注册"
 msgid "New container"
 msgstr "新容器"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project subscription-manager, version 1.10.10, document keys
 msgid "Next"
 msgstr "下一步"
@@ -313,6 +322,9 @@ msgstr "开启"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "开启本机"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"

--- a/locale/zh_TW/foreman_docker.po
+++ b/locale/zh_TW/foreman_docker.po
@@ -109,6 +109,9 @@ msgstr "運算選項"
 msgid "Compute resource"
 msgstr "運算資源"
 
+msgid "Configuration"
+msgstr ""
+
 msgid "Container %s is being deleted."
 msgstr "Container %s 正被刪除中。"
 
@@ -181,6 +184,9 @@ msgstr "此映像檔是否支援使用者資料輸入？"
 
 msgid "Edit Registry"
 msgstr "編輯登錄檔"
+
+msgid "Environment"
+msgstr ""
 
 msgid "Environment Variables"
 msgstr "環境變數"
@@ -274,6 +280,9 @@ msgstr "新增登錄檔"
 msgid "New container"
 msgstr "新增 container"
 
+msgid "New registry"
+msgstr ""
+
 # translation auto-copied from project subscription-manager, version 1.10.10, document keys
 msgid "Next"
 msgstr "下一步"
@@ -313,6 +322,9 @@ msgstr "電源"
 # translation auto-copied from project Satellite6 Foreman, version 6.1, document foreman
 msgid "Power ON this machine"
 msgstr "開啟這部機器的電源"
+
+msgid "Preliminary"
+msgstr ""
 
 # translation auto-copied from project gnome-system-monitor, version 3.8.2.1, document gnome-system-monitor
 msgid "Processes"


### PR DESCRIPTION
Wizard states were shown after calling 'symbol'.to_s.humanize, which
didn't allow them to be translated. I define the strings to be shown
in the helper so that they can be translated.