### PR TITLE
Fixes #10199 - Disable image capabilities under compute resource

### DIFF
--- a/app/models/foreman_docker/docker.rb
+++ b/app/models/foreman_docker/docker.rb
@@ -16,7 +16,7 @@ module ForemanDocker
     end
 
     def capabilities
-      [:image]
+      []
     end
 
     def supports_update?


### PR DESCRIPTION
Docker container images are not created this way, and its just confusing
to users when they see this tab.