### PR TITLE
Fixes #9270 - Add email validation

### DIFF
--- a/app/models/foreman_docker/docker.rb
+++ b/app/models/foreman_docker/docker.rb
@@ -5,6 +5,7 @@ module ForemanDocker
     attr_accessible :email
 
     validates :url, :format => { :with => URI.regexp }
+    validates :email, :format => { :with => /.+@.+\..+/i }, :allow_blank => true
 
     def self.model_name
       ComputeResource.model_name

--- a/test/units/foreman_docker/docker_test.rb
+++ b/test/units/foreman_docker/docker_test.rb
@@ -1,0 +1,10 @@
+require 'test_plugin_helper'
+
+module ForemanDocker
+  class DockerTest < ActiveSupport::TestCase
+    should allow_value('a@b.com').for(:email)
+    should allow_value('').for(:email)
+    should_not allow_value('abcb.com').for(:email)
+    should_not allow_value('a').for(:email)
+  end
+end


### PR DESCRIPTION
Copied the email validation we use for the User model. This catches
errors when creating/updating the Docker compute resource email