### PR TITLE
Fixes #14519 - Removing containers from API removes them from Docker

### DIFF
--- a/app/controllers/api/v2/containers_controller.rb
+++ b/app/controllers/api/v2/containers_controller.rb
@@ -92,7 +92,15 @@ module Api
       param :compute_resource_id, :identifier
 
       def destroy
-        process_response @container.destroy
+        deleted_identifier = ForemanDocker::ContainerRemover.remove_unmanaged(
+          @container.compute_resource_id,
+          @container.uuid)
+
+        if deleted_identifier
+          process_response @container.destroy
+        else
+          render :json => { :error => 'Could not delete container on Docker host' }, :status => :precondition_failed
+        end
       end
 
       api :GET, '/containers/:id/logs', N_('Show container logs')

--- a/app/services/foreman_docker/container_remover.rb
+++ b/app/services/foreman_docker/container_remover.rb
@@ -1,0 +1,20 @@
+module ForemanDocker
+  module ContainerRemover
+    module_function
+
+    def remove_unmanaged(compute_resource_id, uuid)
+      deleted_identifier = uuid
+
+      ComputeResource.
+        authorized(:destroy_compute_resources_vms).
+        find(compute_resource_id).
+        destroy_vm(uuid)
+
+      deleted_identifier
+    rescue => error
+      Rails.logger.
+        error "#{error.message} (#{error.class})\n#{error.backtrace.join("\n")}"
+      false
+    end
+  end
+end

--- a/test/functionals/containers_controller_test.rb
+++ b/test/functionals/containers_controller_test.rb
@@ -15,14 +15,62 @@ class ContainersControllerTest < ActionController::TestCase
     assert_template 'index'
   end
 
-  test 'deleting a container in compute resource redirects to containers index' do
-    Fog.mock!
-    container_resource = FactoryGirl.create(:docker_cr)
-    container          = container_resource.vms.first
-    container.class.any_instance.expects(:destroy).returns(true)
-    delete :destroy, { :compute_resource_id => container_resource,
-                       :id                  => container.id }, set_session_user
-    assert_redirected_to containers_path
+  context 'delete container' do
+    setup do
+      Fog.mock!
+      @container_resource = FactoryGirl.create(:docker_cr)
+      @container          = @container_resource.vms.first
+    end
+
+    teardown { Fog.unmock! }
+
+    test 'deleting an unmanaged container redirects to containers index' do
+      ComputeResource.any_instance.expects(:destroy_vm).with(@container.id)
+      delete :destroy, { :compute_resource_id => @container_resource,
+                         :id                  => @container.id }, set_session_user
+      assert_redirected_to containers_path
+      assert_equal "Container #{@container.id} is being deleted.",
+        flash[:notice]
+    end
+
+    test 'failed deletion of unmanaged container in Docker' do
+      ComputeResource.any_instance.stubs(:destroy_vm).
+        raises(::Foreman::Exception.new('Could not destroy Docker container'))
+      @request.env['HTTP_REFERER'] = "http://test.host/#{containers_path}"
+      delete :destroy, { :compute_resource_id => @container_resource,
+                         :id                  => @container.id }, set_session_user
+      assert @container.present?
+      assert_redirected_to :back
+      assert_equal 'Your container could not be deleted in Docker',
+        flash[:error]
+    end
+
+    test 'deleting a managed container deletes container in Docker' do
+      managed_container = FactoryGirl.create(
+        :container,
+        :compute_resource => @container_resource)
+      ComputeResource.any_instance.expects(:destroy_vm).
+        with('randomuuid')
+      Container.any_instance.expects(:uuid).returns('randomuuid').at_least_once
+      Container.any_instance.expects(:destroy)
+      delete :destroy, { :id => managed_container.id }, set_session_user
+      assert_redirected_to containers_path
+      assert_equal "Container #{managed_container.uuid} is being deleted.",
+        flash[:notice]
+    end
+
+    test 'failed deletion of managed container keeps container in Foreman' do
+      ComputeResource.any_instance.stubs(:destroy_vm).
+        raises(::Foreman::Exception.new('Could not destroy Docker container'))
+      managed_container = FactoryGirl.create(
+        :container,
+        :compute_resource => @container_resource)
+      delete :destroy, { :id => managed_container.id }, set_session_user
+      assert managed_container.present? # Foreman container would not be deleted
+      assert_redirected_to containers_path
+      assert_equal 'Your container could not be deleted in Docker',
+        flash[:error]
+    end
   end
 
   test 'committing a managed container' do

--- a/test/units/container_remover_test.rb
+++ b/test/units/container_remover_test.rb
@@ -1,0 +1,31 @@
+require 'test_plugin_helper'
+
+module ForemanDocker
+  class ContainerRemoverTest < ActiveSupport::TestCase
+    describe '#remove_unmanaged' do
+      setup do
+        @docker_compute_resource = FactoryGirl.build_stubbed(:docker_cr)
+        ComputeResource.expects(:authorized).
+          with(:destroy_compute_resources_vms).
+          returns(stub(:find => @docker_compute_resource))
+
+        Fog.mock!
+      end
+
+      teardown { Fog.unmock! }
+
+      test 'remove_unmanaged makes call to the Docker API' do
+        @docker_compute_resource.expects(:destroy_vm).with('random-uuid')
+
+        assert ForemanDocker::ContainerRemover.remove_unmanaged(
+          @docker_compute_resource.id, 'random-uuid')
+      end
+
+      test 'remove_unmanaged returns deleted_identifier' do
+        assert_equal 'random-uuid',
+          ForemanDocker::ContainerRemover.remove_unmanaged(
+            @docker_compute_resource.id, 'random-uuid')
+      end
+    end
+  end
+end

--- a/test/units/container_test.rb
+++ b/test/units/container_test.rb
@@ -1,4 +1,10 @@
 require 'test_plugin_helper'
 
 class ContainerTest < ActiveSupport::TestCase
+  should belong_to(:compute_resource)
+  should belong_to(:registry)
+  should have_many(:environment_variables)
+  should have_many(:dns)
+  should have_many(:exposed_ports)
+  should validate_uniqueness_of(:name)
 end

--- a/test/units/containers_service_test.rb
+++ b/test/units/containers_service_test.rb
@@ -19,7 +19,9 @@ class ContainersServiceTest < ActiveSupport::TestCase
     end
     ForemanDocker::Docker.any_instance.expects(:create_container)
       .returns(OpenStruct.new(:uuid => 1))
+    Fog.mock!
     Service::Containers.new.start_container!(@state)
+    Fog.unmock!
     assert_equal DockerContainerWizardState.where(:id => @state.id).count, 0
   end
 end


### PR DESCRIPTION
Before this fix, the API was just removing the container in the Foreman
database. This commit includes more tests for both the UI and API
container deletion to ensure this area is a bit more solid.