### PR TITLE
Fixes #14570 - Set docker-api to 1.18 to avoid image parsing errors

### DIFF
--- a/foreman_docker.gemspec
+++ b/foreman_docker.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*', '.rubocop.yml']
 
-  s.add_dependency 'docker-api', '~> 1.17'
+  s.add_dependency 'docker-api', '~> 1.18'
   s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'wicked', '~> 1.1'
 end


### PR DESCRIPTION
Parsing of some images, as well as the warning
'circular argument reference - connection' show up because of an
outdated version of docker-api.