### PR TITLE
Fixes #14662 - Revert new_link to ensure 1.11 compatibility

### DIFF
--- a/app/views/containers/index.html.erb
+++ b/app/views/containers/index.html.erb
@@ -1,6 +1,8 @@
 <% title _("Containers") %>
 
-<%= title_actions(new_link(_("New container"))) %>
+<%= title_actions(display_link_if_authorized(
+  _('New container'),
+  hash_for_new_container_path)) %>
 
 <ul class="nav nav-tabs" data-tabs="tabs">
   <% @container_resources.each_with_index do |resource, i| %>

--- a/app/views/registries/index.html.erb
+++ b/app/views/registries/index.html.erb
@@ -1,6 +1,8 @@
 <% title _("Registries") %>
 
-<%= title_actions(new_link(_("New registry"))) %>
+<%= title_actions(display_link_if_authorized(
+  _('New registry'),
+  hash_for_new_registry_path)) %>
 
 <table class="table table-bordered table-striped table-condensed" data-table="inline">
   </thead>


### PR DESCRIPTION
new_link was a helper for "New XXXX" links in Foreman that was
introduced on 1.12-develop branch. If we want to make the new changes in
foreman-docker available to current users, we should revert new_link to
'display_if_authorized...'.