### PR TITLE
fixes #14769 - use css instead of unless to hide profiles tab

### DIFF
--- a/app/overrides/remove_docker_from_compute_profiles.rb
+++ b/app/overrides/remove_docker_from_compute_profiles.rb
@@ -10,5 +10,5 @@ Deface::Override.new(
   :virtual_path => 'compute_resources/show',
   :name => 'remove_compute_profiles_tab',
   :replace => 'a[href="#compute_profiles"]',
-  :text => "<%= link_to(_('Compute profiles'), '#compute_profiles', :'data-toggle' => 'tab') unless @compute_resource.type == 'ForemanDocker::Docker' %>"
+  :text => "<%= link_to(_('Compute profiles'), '#compute_profiles', :'data-toggle' => 'tab', :'style' => \"\#{@compute_resource.type == 'ForemanDocker::Docker' ? 'display: none;' : ''}\") %>"
 )


### PR DESCRIPTION
This isn't working on EL6, older deface seems unable to support statement
modifiers in the deface text