### PR TITLE
Fixes #15107 - Rails 4.2 test breakages

### DIFF
--- a/app/views/containers/steps/preliminary.html.erb
+++ b/app/views/containers/steps/preliminary.html.erb
@@ -21,8 +21,9 @@
         <hr>
         <%= select_f f, 'compute_resource_id', @container_resources, :id, :to_label, {}, { :label => _('Deploy on') } %>
       <% else %>
+
         <div class="alert alert-warning alert-dismissable">
-          <%= image_tag 'false.png' %> <%= (_("You need a Docker compute resource in order to create containers. Please %s and try again.") % link_to('add a new one', hash_for_new_compute_resource_path)).html_safe %>
+          <%= image_tag 'false.png' %> <%= (_("You need a Docker compute resource in order to create containers. Please %s and try again.") % link_to('add a new one', new_compute_resource_path)).html_safe %>
         </div>
       <% end %>
     </div>

--- a/lib/foreman_docker/tasks/test.rake
+++ b/lib/foreman_docker/tasks/test.rake
@@ -8,6 +8,7 @@ namespace :test do
         "#{ForemanDocker::Engine.root}/test/**/*_test.rb"
       ]
       t.verbose = true
+      t.warning = false
     end
 
     Rake::Task[test_task.name].invoke


### PR DESCRIPTION
url_for in the new Rails carries some parameters that can break the link
creation. Additionally I've disabled ruby warnings in the rake test task.