### PR TITLE
Refs #14570 - Fetch tags from local images properly

### DIFF
--- a/app/models/foreman_docker/docker.rb
+++ b/app/models/foreman_docker/docker.rb
@@ -61,7 +61,7 @@ module ForemanDocker
 
     def tags(image_name)
       if exist?(image_name)
-        tags_for_local_image(local_images(image_name).first)
+        tags_for_local_image(image(image_name))
       else
         # If image is not found in the compute resource, get the tags from the Hub
         hub_api_url = "https://index.docker.io/v1/repositories/#{image_name}/tags"


### PR DESCRIPTION
We were calling local_images and passing an ID as filter. However,
that didn't work. Instead we can fetch the image just by calling
image(image_id) and that should retrieve the image object so we can call
.info , etc.. on it.