### PR TITLE
Fixes #16594 - Capitalize the first letter of every word

### DIFF
--- a/lib/foreman_docker/engine.rb
+++ b/lib/foreman_docker/engine.rb
@@ -47,10 +47,10 @@ module ForemanDocker
 
         sub_menu :top_menu, :containers_menu, :caption => N_('Containers'),
                                               :after => :monitor_menu do
-          menu :top_menu, :containers,    :caption => N_('All containers'),
+          menu :top_menu, :containers,    :caption => N_('All Containers'),
                                           :url_hash => { :controller => :containers,
                                                          :action => :index }
-          menu :top_menu, :new_container, :caption => N_('New container'),
+          menu :top_menu, :new_container, :caption => N_('New Container'),
                                           :url_hash => { :controller => :containers,
                                                          :action => :new }
           menu :top_menu, :registries, :caption => N_('Registries'),


### PR DESCRIPTION
To keep consistent in Foreman, we suggested to capitalize the first letter of every word in the menu.
FYI: https://github.com/theforeman/foreman/pull/3841

Thanks
