### PR TITLE
Refs #14370 - Adding new_link helper to containers and registries

### DIFF
--- a/app/views/containers/index.html.erb
+++ b/app/views/containers/index.html.erb
@@ -1,8 +1,6 @@
 <% title _("Containers") %>
 
-<%= title_actions(display_link_if_authorized(
-  _('New container'),
-  hash_for_new_container_path)) %>
+<%= title_actions(new_link(_("New container"))) %>
 
 <ul class="nav nav-tabs" data-tabs="tabs">
   <% @container_resources.each_with_index do |resource, i| %>

--- a/app/views/registries/index.html.erb
+++ b/app/views/registries/index.html.erb
@@ -1,8 +1,6 @@
 <% title _("Registries") %>
 
-<%= title_actions(display_link_if_authorized(
-  _('New registry'),
-  hash_for_new_registry_path)) %>
+<%= title_actions(new_link(_("New registry"))) %>
 
 <table class="table table-bordered table-striped table-condensed" data-table="inline">
   </thead>


### PR DESCRIPTION
Part of the original PR was reverted because the new_link helper didn't exist in 1.11. Now that 1.13 is already released the helper should be used.