### PR TITLE
Fixes #17729 - APIdoc - URL desc add 'Docker' to CR types

### DIFF
--- a/app/models/foreman_docker/compute_resource_extensions.rb
+++ b/app/models/foreman_docker/compute_resource_extensions.rb
@@ -1,0 +1,11 @@
+module ForemanDocker
+  module ComputeResourceExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      def self.providers_requiring_url
+        _("Docker, Libvirt, oVirt, OpenStack and Rackspace")
+      end
+    end
+  end
+end

--- a/lib/foreman_docker/engine.rb
+++ b/lib/foreman_docker/engine.rb
@@ -146,6 +146,7 @@ module ForemanDocker
       # Compatibility fixes - to be removed once 1.7 compatibility is no longer required
       Fog::Compute::Fogdocker::Images.send(:include, ::FogExtensions::Fogdocker::Images)
       ::Taxonomy.send(:include, ForemanDocker::TaxonomyExtensions)
+      ComputeResource.send(:include, ForemanDocker::ComputeResourceExtensions)
     end
   end
 end

--- a/test/units/foreman_docker/compute_resource_extensions_test.rb
+++ b/test/units/foreman_docker/compute_resource_extensions_test.rb
@@ -1,0 +1,10 @@
+require 'test_plugin_helper'
+
+module ForemanDocker
+  class ComputeResourceExtensionsTest < ActiveSupport::TestCase
+    test 'ComputeResource::providers_requiring_url returns expected providers' do
+      expected_providers = "Docker, Libvirt, oVirt, OpenStack and Rackspace"
+      assert_equal expected_providers, ComputeResource.providers_requiring_url
+    end
+  end
+end


### PR DESCRIPTION
This is related to https://github.com/theforeman/foreman/pull/4113
Please merge in order:
1. https://github.com/theforeman/foreman/pull/4113
2. Then this PR