### PR TITLE
Fixes #18502 - Add excon version 0.46 and above as dependency

### DIFF
--- a/foreman_docker.gemspec
+++ b/foreman_docker.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*', '.rubocop.yml']
 
   s.add_dependency 'docker-api', '~> 1.18'
+  s.add_dependency 'excon', '~> 0.46'
   s.add_dependency 'deface', '< 2.0'
   s.add_dependency 'wicked', '~> 1.1'
 end


### PR DESCRIPTION
The excon gem, required by docker-api, version 0.45 and below
give a malformed empty head to socket connections.
Version ~> 0.46 have this fixed and address the issue in #18502.

Adding excon as a direct dependency is not optimal, therefore the lowest possible version that includes the fix will be required.

To reproduce the issue:
 1. Run bundle install with master
 1. Uninstall all `excon` gems.
 1. Install version `0.45.0`
 1. Run `bundle install` to verify that version `0.45.0` will be used.
 1. Restart Foreman
 1. Reproduce the issue with steps described on redmine.
 1. Checkout the fix branch
 1. Run bundle update. This will install a newer or newest available version of the gem
 1. Restart Foreman
 1. Malformed Header Error is gone and connection is working as expected.