### PR TITLE
Fixes #14175 - Add support for Docker Registry v2

### DIFF
--- a/app/controllers/image_search_controller.rb
+++ b/app/controllers/image_search_controller.rb
@@ -25,9 +25,14 @@ class ImageSearchController < ::ApplicationController
              else
                registry_auto_complete_image_tags(params[:search])
              end
+
+      tags = tags.map do |tag|
+        tag = CGI.escapeHTML(tag)
+        { :label => tag, :value => tag }
+      end
+
       respond_to do |format|
         format.js do
-          tags.map! { |tag| { :label => CGI.escapeHTML(tag), :value => CGI.escapeHTML(tag) } }
           render :json => tags
         end
       end
@@ -103,7 +108,7 @@ class ImageSearchController < ::ApplicationController
   def registry_auto_complete_image_tags(terms)
     ::Service::RegistryApi.new(:url => @registry.url,
                                :user => @registry.username,
-                               :password => @registry.password).list_repository_tags(terms).keys
+                               :password => @registry.password).tags(terms).map { |t| t['name'] }
   end
 
   def registry_search_image(terms)

--- a/app/models/docker_registry.rb
+++ b/app/models/docker_registry.rb
@@ -42,13 +42,16 @@ class DockerRegistry < ActiveRecord::Base
     _("Docker/Registry")
   end
 
+  def api
+    @api ||= Service::RegistryApi.new(url: url,
+                                      user: username,
+                                      password: password)
+  end
+
   private
 
   def attempt_login
-    login_endpoint = RestClient::Resource.new(url + '/v1/users',
-                                              :user => username,
-                                              :password => password)
-    login_endpoint.get == "\"OK\""
+    api.ok?
   rescue => e
     errors.add(:base, _('Unable to log in to this Docker Registry - %s') % e)
   end

--- a/app/models/service/registry_api.rb
+++ b/app/models/service/registry_api.rb
@@ -1,26 +1,96 @@
 module Service
   class RegistryApi
-    DEFAULTS = { :url => 'http://localhost:5000' }
-    attr_reader :config
+    DOCKER_HUB = 'https://registry.hub.docker.com/'.freeze
+    DEFAULTS = {
+      url: 'http://localhost:5000'.freeze,
+      connection: { omit_default_port: true }
+    }
+
+    attr_accessor :config, :url
+    delegate :logger, :to => Rails
 
     def initialize(params = {})
-      config = DEFAULTS.merge(params)
-      uri = URI(config.delete(:url))
-      uri.user = config.delete(:user) unless config[:user].blank?
-      uri.password = config.delete(:password) unless config[:password].blank?
-      @config = config.merge(:url => uri.to_s)
+      self.config = DEFAULTS.merge(params)
+      self.url = config[:url]
+      @user = config[:user] unless config[:user].blank?
+      @password = config[:password] unless config[:password].blank?
+
+      Docker.logger = logger if Rails.env.development? || Rails.env.test?
     end
 
-    def search(aquery)
-      response = RestClient.get(config[:url] + '/v1/search',
-                                :params => { :q => aquery }, :accept => :json)
-      JSON.parse(response.body)
+    def connection
+      @connection ||= ::Docker::Connection.new(url, credentials)
     end
 
-    def list_repository_tags(arepository)
-      response = RestClient.get(config[:url] + "/v1/repositories/#{arepository}/tags",
-                                :accept => :json)
-      JSON.parse(response.body)
+    def get(path, params = nil)
+      response = connection.get('/'.freeze, params,
+                                DEFAULTS[:connection].merge({ path: "#{path}" }))
+      response = parse_json(response)
+      response
+    end
+
+    # Since the Registry API v2 does not support a search the v1 endpoint is used
+    # Newer registries will fail, the v2 catalog endpoint is used
+    def search(query)
+      get('/v1/search'.freeze, { q: query })
+    rescue => e
+      logger.warn "API v1 - Search failed #{e.backtrace}"
+      { 'results' => catalog(query) }
+    end
+
+    # Some Registries might have this endpoint not implemented/enabled
+    def catalog(query)
+      get('/v2/_catalog'.freeze)['repositories'].select do |image|
+        image =~ /^#{query}/
+      end.map { |image_name| { 'name' => image_name } }
+    end
+
+    def tags(image_name, query = nil)
+      result = get_tags(image_name)
+      result = result.keys.map { |t| {'name' => t.to_s } } if result.is_a? Hash
+      result = filter_tags(result, query) if query
+      result
+    end
+
+    def ok?
+      get('/v1/'.freeze).match("Docker Registry API")
+    rescue => e
+      logger.warn "API v1 - Ping failed #{e.backtrace}"
+      get('/v2/'.freeze).is_a? Hash
+    end
+
+    def self.docker_hub
+      @@docker_hub ||= new(url: DOCKER_HUB)
+    end
+
+    private
+
+    def parse_json(string)
+      JSON.parse(string)
+    rescue => e
+      logger.warn "JSON parsing failed: #{e.backtrace}"
+      string
+    end
+
+    def get_tags(image_name)
+      get("/v1/repositories/#{image_name}/tags")
+    rescue => e
+      logger.warn "API v1 - Repository images request failed #{e.backtrace}"
+      tags_v2(image_name)
+    end
+
+    def tags_v2(image_name)
+      get("/v2/#{image_name}/tags/list")['tags'].map { |tag| { 'name' => tag } }
+    end
+
+    def credentials
+      { user: @user, password: @password }
+    end
+
+    def filter_tags(result, query)
+      result.select do |tag_name|
+        tag_name['name'] =~ /^#{query}/
+      end
     end
   end
 end

--- a/test/functionals/api/v2/registries_controller_test.rb
+++ b/test/functionals/api/v2/registries_controller_test.rb
@@ -43,15 +43,16 @@ module Api
 
       test 'update a docker registry' do
         DockerRegistry.any_instance.stubs(:attempt_login)
-        put :update, :id => @registry.id, :registry => { :name => 'hello_world' }
+        new_name = 'hello_world'
+        put :update, :id => @registry.id, :registry => { :name => new_name }
         assert_response :success
-        assert DockerRegistry.exists?(:name => 'hello_world')
+        assert_equal new_name, @registry.reload.name
       end
 
       test 'deletes a docker registry' do
         delete :destroy, :id => @registry.id
         assert_response :success
-        refute DockerRegistry.exists?(@registry.id)
+        assert DockerRegistry.where(:id => @registry.id).blank?
       end
     end
   end

--- a/test/functionals/image_search_controller_test.rb
+++ b/test/functionals/image_search_controller_test.rb
@@ -5,6 +5,19 @@ class ImageSearchControllerTest < ActionController::TestCase
     @container = FactoryGirl.create(:docker_cr)
   end
 
+  describe '#auto_complete_image_tag' do
+    let(:tags) { ['latest', '5', '4.3'] }
+
+    test 'returns an array of { label:, value: } hashes' do
+      ForemanDocker::Docker.any_instance.expects(:tags)
+        .with('test')
+        .returns(tags)
+      get :auto_complete_image_tag,
+          { search: "test", id: @container.id, format: :js }, set_session_user
+      assert_equal tags.first, JSON.parse(response.body).first['value']
+    end
+  end
+
   [Docker::Error::DockerError, Excon::Errors::Error, Errno::ECONNREFUSED].each do |error|
     test 'auto_complete_repository_name catches exceptions on network errors' do
       ForemanDocker::Docker.any_instance.expects(:exist?).raises(error)

--- a/test/units/registry_api_test.rb
+++ b/test/units/registry_api_test.rb
@@ -1,17 +1,210 @@
 require 'test_plugin_helper'
 
 class RegistryApiTest < ActiveSupport::TestCase
-  test "initialize handles username password info correctly" do
-    uname = "tardis"
-    password = "boo"
-    url = "http://docker-who.gov"
-    reg = Service::RegistryApi.new(:url => url,
-                                   :user => uname,
-                                   :password => password)
-    assert reg.config[:url].include?(uname)
-    assert reg.config[:url].include?(password)
+  let(:url) { 'http://dockerregistry.com:5000' }
+  subject { Service::RegistryApi.new(url: url) }
 
-    reg = Service::RegistryApi.new(:url => url)
-    assert_equal url, reg.config[:url]
+  describe '#connection' do
+    test 'returns a Docker::Connection' do
+      assert_equal Docker::Connection, subject.connection.class
+    end
+
+    test 'the connection has the same url' do
+      assert_equal url, subject.connection.url
+    end
+
+    context 'authentication is set' do
+      let(:user) { 'username' }
+      let(:password) { 'secretpassword' }
+
+      subject do
+        Service::RegistryApi.new({
+          url: url,
+          password: password,
+          user: user })
+      end
+
+      test 'it sets the same user and password' do
+        assert_equal user, subject.connection.options[:user]
+        assert_equal password, subject.connection.options[:password]
+      end
+    end
+  end
+
+  describe '#get' do
+    let(:path) { '/v1/search' }
+    let(:json) { '{}' }
+
+    test 'calls get on #connection' do
+      subject.connection
+        .expects(:get).at_least_once
+        .returns(json)
+
+      subject.get(path)
+    end
+
+    test 'returns a parsed json' do
+      subject.connection.stubs(:get).returns(json)
+      assert_equal JSON.parse(json), subject.get(path)
+    end
+
+    # Docker::Connection is used and meant for the Docker,
+    # not the Registry API therefore it is required
+    # to override the path via options
+    test 'sets the path as an option not param for Docker::Connection#get' do
+      subject.connection.stubs(:get) do |path_param, _, options|
+        refute_equal path, path_param
+        assert_equal path, options[:path]
+      end.returns(json)
+
+      subject.get(path)
+    end
+
+    # Docker Hub will return a 503 when a 'Host' header includes a port.
+    # Omitting default ports (an Excon option) solves the issue
+    test 'sets omit_default_port to true' do
+      subject.connection.stubs(:get) do |_, _, options|
+        assert options[:omit_default_port]
+      end.returns(json)
+
+      subject.get(path)
+    end
+
+    test 'returns the response raw body if it is not JSON' do
+      response = 'This is not JSON'
+      subject.connection.stubs(:get)
+        .returns(response)
+      assert_equal response, subject.get('/v1/')
+    end
+  end
+
+  describe '#search' do
+    let(:path) { '/v1/search' }
+    let(:query) { 'centos' }
+
+    test "calls #get with path and query" do
+      subject.expects(:get).with(path, {q: query}) do |path_param, params|
+        assert_equal path, path_param
+        assert_equal query, params[:q]
+      end.returns({})
+
+      subject.search(query)
+    end
+
+    test "falls back to #catalog if #get fails" do
+      subject.expects(:catalog).with(query)
+
+      subject.expects(:get).with(path, {q: query})
+        .raises('Error')
+
+      subject.search(query)
+    end
+  end
+
+  describe '#catalog' do
+    let(:path) { '/v2/_catalog' }
+    let(:query) { 'centos' }
+    let(:catalog) { { 'repositories' => ['centos', 'fedora'] } }
+
+    setup do
+      subject.stubs(:get).returns(catalog)
+    end
+
+    test "calls #get with path" do
+      subject.expects(:get).with(path)
+        .returns(catalog)
+
+      subject.catalog(query)
+    end
+
+    test 'returns {"name" => value} pairs' do
+      result = subject.catalog(query)
+      assert_equal({ "name" => query }, result.first)
+    end
+
+    test 'only give back matching results' do
+      result = subject.catalog('fedora')
+      assert_match(/^fedora/, result.first['name'])
+    end
+  end
+
+  describe '#tags' do
+    let(:query) { 'alpine' }
+    let(:path) { "/v1/repositories/#{query}/tags" }
+
+    test "calls #get with path" do
+      subject.expects(:get).with(path)
+      subject.tags(query)
+    end
+
+    test "falls back to #tags_v2 if #get fails" do
+      subject.expects(:get).with(path)
+        .raises('Error')
+
+      subject.expects(:tags_v2).with(query)
+      subject.tags(query)
+    end
+
+    # https://registry.access.redhat.com returns a hash not an array
+    test 'handles a hash response correctly' do
+      tags_hash = {
+        "7.0-21": "e1f5733f050b2488a17b7630cb038bfbea8b7bdfa9bdfb99e63a33117e28d02f",
+	"7.0-23": "bef54b8f8a2fdd221734f1da404d4c0a7d07ee9169b1443a338ab54236c8c91a",
+	"7.0-27": "8e6704f39a3d4a0c82ec7262ad683a9d1d9a281e3c1ebbb64c045b9af39b3940"
+      }
+      subject.expects(:get).with(path)
+        .returns(tags_hash)
+      assert_equal '7.0-21', subject.tags(query).first['name']
+    end
+  end
+
+  describe '#tags for API v2' do
+    let(:query) { 'debian' }
+    let(:v1_path) { "/v1/repositories/#{query}/tags" }
+    let(:path) { "/v2/#{query}/tags/list" }
+    let(:tags) { { 'tags' => ['jessy', 'woody'] } }
+
+    setup do
+      subject.stubs(:get).with(v1_path)
+        .raises('404 Not found')
+    end
+
+    test 'calls #get with path' do
+      subject.expects(:get).with(path)
+        .returns(tags)
+      subject.tags(query)
+    end
+
+    test 'returns {"name" => value } pairs ' do
+      subject.stubs(:get).with(path).returns(tags)
+      result = subject.tags(query)
+      assert_equal tags['tags'].first, result.first['name']
+    end
+  end
+
+  describe '#ok?' do
+    test 'calls the API via #get with /v1/' do
+      subject.connection.expects(:get)
+        .with('/', nil, Service::RegistryApi::DEFAULTS[:connection].merge({ path: '/v1/' }))
+        .returns('Docker Registry API')
+      assert subject.ok?
+    end
+
+    test 'calls #get with /v2/ if /v1/fails' do
+      subject.stubs(:get).with('/v1/')
+        .raises('404 page not found')
+      subject.expects(:get).with('/v2/')
+        .returns({})
+      assert subject.ok?
+    end
+  end
+
+  describe '.docker_hub' do
+    subject { Service::RegistryApi }
+
+    test 'returns an instance for Docker Hub' do
+      result = subject.docker_hub
+      assert_equal Service::RegistryApi::DOCKER_HUB, result.url
+    end
   end
 end


### PR DESCRIPTION
This adds more functionality to RegisrtyApi and queries /v2/ endpoints in case requests to v1 of the registry API fail.

For now only public registries not requiring authentication are supported. 
The change to support authenticated v2-only registries is a topic on it's own and i wanted to keep this out of here and first have general support for the endpoints

GitLab implements the same authentication as Docker Hub using the same endpoints to get an OAuth token to use for authenticating requests. 

I still need to investigate further on the details to follow up with a PR, after #183 is fully merged, that adds the possibility to choose either OAuth-type authentication or plain basic HTTP auth as it is now with v1 endpoints that support it.
