### PR TITLE
Fixes #18733 - Prevent fallback to Docker Hub on registry search

### DIFF
--- a/app/helpers/container_steps_helper.rb
+++ b/app/helpers/container_steps_helper.rb
@@ -34,6 +34,15 @@ module ContainerStepsHelper
     active_tab.to_s == tab_name.to_s ? "active" : ""
   end
 
+  # el7 returns -> "name" => "docker.io: docker.io/centos",
+  # while f20 returns -> "name" => "centos"
+  # we need repo name to be => "docker.io/centos" for el7 and "centos" for fedora
+  # to ensure proper search with respect to the tags, image creation etc.
+  def cleanup_image_name(name)
+    name.split.last
+  end
+
+
   def model_for(registry_type)
     if active_tab.to_s == registry_type.to_s
       @docker_container_wizard_states_image

--- a/app/models/docker_registry.rb
+++ b/app/models/docker_registry.rb
@@ -43,8 +43,7 @@ class DockerRegistry < ActiveRecord::Base
   end
 
   def api
-    @api ||= Service::RegistryApi.new(url: url,
-                                      user: username,
+    @api ||= Service::RegistryApi.new(url: url, user: username,
                                       password: password)
   end
 

--- a/app/models/foreman_docker/docker.rb
+++ b/app/models/foreman_docker/docker.rb
@@ -61,11 +61,7 @@ module ForemanDocker
       if exist?(image_name)
         tags_for_local_image(image(image_name))
       else
-        # If image is not found in the compute resource, get the tags from the Hub
-        hub_api_url = "https://index.docker.io/v1/repositories/#{image_name}/tags"
-        JSON.parse(URI.parse(hub_api_url).read).map do |tag|
-          tag['name']
-        end
+        Service::RegistryApi.docker_hub.tags(image_name).map { |tag| tag['name'] }
       end
     end
 

--- a/app/models/service/registry_api.rb
+++ b/app/models/service/registry_api.rb
@@ -59,6 +59,12 @@ module Service
       get('/v2/'.freeze).is_a? Hash
     end
 
+    def ok?
+      get('/v1/').match("Docker Registry API")
+    rescue
+      get('/v2/').is_a? Hash
+    end
+
     def self.docker_hub
       @@docker_hub ||= new(url: DOCKER_HUB)
     end

--- a/app/services/foreman_docker/image_search.rb
+++ b/app/services/foreman_docker/image_search.rb
@@ -1,0 +1,92 @@
+module ForemanDocker
+  class ImageSearch
+    def initialize(*args)
+      @sources = {}
+      args.each do |source|
+        add_source(source)
+      end
+    end
+
+    def add_source(source)
+      case source
+      when ForemanDocker::Docker
+        @sources[:compute_resource] ||= []
+        @sources[:compute_resource] << source
+      when Service::RegistryApi
+        @sources[:registry] ||= []
+        @sources[:registry] << source
+      end
+    end
+
+    def remove_source(source)
+      @sources.each do |_, sources|
+        sources.delete(source)
+      end
+    end
+
+    def search(query)
+      return [] if query[:term].blank? || query[:term] == ':'
+
+      unless query[:tags] == 'true'
+        images(query[:term])
+      else
+        tags(query[:term])
+      end
+    end
+
+    def images(query)
+      sources_results_for(:search, query)
+    end
+
+    def tags(query)
+      image_name, tag = query.split(':')
+      sources_results_for(:tags, image_name, tag)
+        .map { |tag_name| { 'name' => tag_name } }
+    end
+
+    def available?(query)
+      tags(query).present?
+    end
+
+    private
+
+    def registry_search(registry, term)
+      registry.search(term)['results']
+    end
+
+    def compute_resource_search(compute_resource, query)
+      images = compute_resource.local_images(query)
+      images.flat_map do |image|
+        image.info['RepoTags'].map do |tag|
+          { 'name' => tag.split(':').first }
+        end
+      end.uniq
+    end
+
+    def compute_resource_image(compute_resource, image_name)
+      compute_resource.image(image_name)
+    rescue ::Docker::Error::NotFoundError
+      nil
+    end
+
+    def compute_resource_tags(compute_resource, image_name, tag)
+      image = compute_resource_image(compute_resource, image_name)
+      image ? compute_resource.tags_for_local_image(image, tag) : []
+    end
+
+    def registry_tags(registry, image_name, tag)
+      registry.tags(image_name, tag).map { |t| t['name'] }
+    end
+
+    def sources_results_for(search, *args)
+      result = []
+      @sources.each do |kind, sources|
+        sources.each do |source|
+          result << self.send("#{kind}_#{search}", source, *args)
+        end
+      end
+      result.flatten.compact
+    end
+  end
+end
+

--- a/app/views/image_search/_repository_search_results.html.erb
+++ b/app/views/image_search/_repository_search_results.html.erb
@@ -1,5 +1,5 @@
 <% repositories.each do |repository| %>
-    <h3><%= link_to repository['name'], '#', :onclick => 'repoSelected(this)', "data-hub" => use_hub %></h3>
+    <h3><%= link_to cleanup_image_name(repository['name']), '#', :onclick => 'repoSelected(this)', "data-hub" => use_hub %></h3>
     <p>
       <%= '<span class="glyphicon glyphicon-certificate" title="Official"></span>'.html_safe if repository['is_official'] %>
       <%= '<span class="glyphicon glyphicon-thumbs-up" title="Trusted"></span>'.html_safe    if repository['is_trusted'] %>

--- a/test/functionals/image_search_controller_test.rb
+++ b/test/functionals/image_search_controller_test.rb
@@ -1,40 +1,179 @@
 require 'test_plugin_helper'
 
 class ImageSearchControllerTest < ActionController::TestCase
+  let(:image) { 'centos' }
+  let(:tags) { ['latest', '5', '4.3'].map { |tag| "#{term}:#{tag}" } }
+  let(:term) { image }
+
+  let(:docker_hub) { Service::RegistryApi.new(url: 'https://nothub.com') }
+  let(:compute_resource) { FactoryGirl.create(:docker_cr) }
+  let(:registry) { FactoryGirl.create(:docker_registry) }
+  let(:image_search_service) { ForemanDocker::ImageSearch.new }
+
   setup do
-    @container = FactoryGirl.create(:docker_cr)
+    Service::RegistryApi.stubs(:docker_hub).returns(docker_hub)
+    ComputeResource::ActiveRecord_Relation.any_instance
+      .stubs(:find).returns(compute_resource)
+    DockerRegistry::ActiveRecord_Relation.any_instance
+      .stubs(:find).returns(registry)
+  end
+
+  describe '#auto_complete_repository_name' do
+    test 'returns if an image is available' do
+      exists = ['true', 'false'].sample
+      search_type = ['hub', 'registry'].sample
+      subject.instance_variable_set(:@image_search_service, image_search_service)
+      image_search_service.expects(:available?).returns(exists)
+
+      xhr :get, :auto_complete_repository_name,
+        { registry: search_type, search: term,
+          id: compute_resource }, set_session_user
+      assert_equal exists, response.body
+    end
+
+    context 'it is a Docker Hub tab request' do
+      let(:search_type) { 'hub' }
+
+      test 'it queries the compute_resource and Docker Hub' do
+        compute_resource.expects(:image).with(term)
+          .returns(term)
+        compute_resource.expects(:tags_for_local_image)
+          .returns(tags)
+        docker_hub.expects(:tags).returns([])
+
+        xhr :get, :auto_complete_repository_name,
+          { registry: search_type, search: term,
+            id: compute_resource }, set_session_user
+      end
+    end
+
+    context 'it is a External Registry tab request' do
+      let(:search_type) { 'registry' }
+
+      test 'it only queries the registry api' do
+        compute_resource.expects(:image).with(term).never
+        docker_hub.expects(:tags).never
+        registry.api.expects(:tags).with(term, nil)
+          .returns(['latest'])
+
+        xhr :get, :auto_complete_repository_name,
+          { registry: search_type, registry_id: registry,
+            search: term, id: compute_resource }, set_session_user
+      end
+    end
   end
 
   describe '#auto_complete_image_tag' do
-    let(:tags) { ['latest', '5', '4.3'] }
+    let(:tag_fragment) { 'lat' }
+    let(:term) { "#{image}:#{tag_fragment}"}
 
     test 'returns an array of { label:, value: } hashes' do
-      ForemanDocker::Docker.any_instance.expects(:tags)
-        .with('test')
+      search_type = ['hub', 'registry'].sample
+      subject.instance_variable_set(:@image_search_service, image_search_service)
+      image_search_service.expects(:search)
+        .with({ term: term, tags: 'true' })
         .returns(tags)
-      get :auto_complete_image_tag,
-          { search: "test", id: @container.id, format: :js }, set_session_user
+      xhr :get, :auto_complete_image_tag,
+        { registry: search_type, search: term,
+          id: compute_resource }, set_session_user
       assert_equal tags.first, JSON.parse(response.body).first['value']
+    end
+
+    context 'a Docker Hub tab request' do
+      let(:search_type) { 'hub' }
+
+      test 'it searches Docker Hub and the ComputeResource' do
+        compute_resource.expects(:image).with(image)
+          .returns(term)
+        compute_resource.expects(:tags_for_local_image)
+          .returns(tags)
+        docker_hub.expects(:tags).returns([])
+
+        xhr :get, :auto_complete_image_tag,
+          { registry: search_type, search: term,
+            id: compute_resource }, set_session_user
+      end
+    end
+
+    context 'it is a External Registry tab request' do
+      let(:search_type) { 'registry' }
+
+      test 'it only queries the registry api' do
+        compute_resource.expects(:image).with(image).never
+        docker_hub.expects(:tags).never
+        registry.api.expects(:tags).with(image, tag_fragment)
+          .returns([])
+
+        xhr :get, :auto_complete_image_tag,
+          { registry: search_type, registry_id: registry,
+            search: term, id: compute_resource }, set_session_user
+      end
+    end
+  end
+
+  describe '#search_repository' do
+    test 'returns html with the found images' do
+      search_type = ['hub', 'registry'].sample
+      subject.instance_variable_set(:@image_search_service, image_search_service)
+      image_search_service.expects(:search)
+        .with({ term: term, tags: 'false' })
+        .returns([{ 'name' => term}])
+      xhr :get, :search_repository,
+        { registry: search_type, search: term,
+          id: compute_resource }, set_session_user
+      assert response.body.include?(term)
+    end
+
+    context 'a Docker Hub tab request' do
+      let(:search_type) { 'hub' }
+
+      test 'it searches Docker Hub and the ComputeResource' do
+        compute_resource.expects(:local_images)
+          .returns([OpenStruct.new(info: { 'RepoTags' => [term] })])
+        docker_hub.expects(:search).returns({})
+
+        xhr :get, :search_repository,
+          { registry: search_type, search: term,
+            id: compute_resource }, set_session_user
+      end
+    end
+
+    context 'it is a External Registry tab request' do
+      let(:search_type) { 'registry' }
+
+      test 'it only queries the registry api' do
+        compute_resource.expects(:local_images).with(image).never
+        docker_hub.expects(:search).never
+        registry.api.expects(:search).with(image)
+          .returns({})
+
+        xhr :get, :search_repository,
+          { registry: search_type, registry_id: registry,
+            search: term, id: compute_resource }, set_session_user
+      end
     end
   end
 
   [Docker::Error::DockerError, Excon::Errors::Error, Errno::ECONNREFUSED].each do |error|
     test 'auto_complete_repository_name catches exceptions on network errors' do
-      ForemanDocker::Docker.any_instance.expects(:exist?).raises(error)
-      get :auto_complete_repository_name, { :search => "test", :id => @container.id },
-          set_session_user
+      ForemanDocker::ImageSearch.any_instance.expects(:available?)
+        .raises(error)
+      xhr :get, :auto_complete_repository_name,
+        { registry: 'hub', search: term, id: compute_resource }, set_session_user
       assert_response_is_expected
     end
 
     test 'auto_complete_image_tag catch exceptions on network errors' do
-      ForemanDocker::Docker.any_instance.expects(:tags).raises(error)
-      get :auto_complete_image_tag, { :search => "test", :id => @container.id }, set_session_user
+      ForemanDocker::ImageSearch.any_instance.expects(:search).raises(error)
+      xhr :get, :auto_complete_image_tag,
+        { registry: 'hub', search:  term, id: compute_resource }, set_session_user
       assert_response_is_expected
     end
 
     test 'search_repository catch exceptions on network errors' do
-      ForemanDocker::Docker.any_instance.expects(:search).raises(error)
-      get :search_repository, { :search => "test", :id => @container.id }, set_session_user
+      ForemanDocker::ImageSearch.any_instance.expects(:search).raises(error)
+      xhr :get, :search_repository,
+        { registry: 'hub', search: term, id: compute_resource }, set_session_user
       assert_response_is_expected
     end
   end
@@ -49,8 +188,9 @@ class ImageSearchControllerTest < ActionController::TestCase
                    "name" =>  repo_full_name,
                    "star_count" => 0
                 }]
-    ForemanDocker::Docker.any_instance.expects(:search).returns(expected).at_least_once
-    get :search_repository, { :search => "centos", :id => @container.id }, set_session_user
+    ForemanDocker::ImageSearch.any_instance.expects(:search).returns(expected).at_least_once
+    xhr :get, :search_repository,
+      { registry: 'hub', search: 'centos', id: compute_resource }, set_session_user
     assert_response :success
     refute response.body.include?(repo_full_name)
     assert response.body.include?(repository)
@@ -66,8 +206,9 @@ class ImageSearchControllerTest < ActionController::TestCase
                   "name" =>  repo_full_name,
                   "star_count" => 0
                 }]
-    ForemanDocker::Docker.any_instance.expects(:search).returns(expected).at_least_once
-    get :search_repository, { :search => "centos", :id => @container.id }, set_session_user
+    ForemanDocker::ImageSearch.any_instance.expects(:search).returns(expected).at_least_once
+    xhr :get, :search_repository,
+      { registry: 'hub', search: 'centos', id: compute_resource  }, set_session_user
     assert_response :success
     assert response.body.include?(repo_full_name)
     assert response.body.include?(repository)

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -12,3 +12,14 @@ end
 # Add plugin to FactoryGirl's paths
 FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 FactoryGirl.reload
+
+def stub_image_existance(exists = true)
+  Docker::Image.any_instance.stubs(:exist?).returns(exists)
+  ForemanDocker::ImageSearch.any_instance.stubs(:available?).returns(exists)
+end
+
+def stub_registry_api
+  Service::RegistryApi.any_instance.stubs(:get).returns({'results' => []})
+  Docker::Image.stubs(:all).returns([])
+end
+

--- a/test/units/docker_registry_test.rb
+++ b/test/units/docker_registry_test.rb
@@ -55,4 +55,12 @@ class DockerRegistryTest < ActiveSupport::TestCase
       assert_kind_of Service::RegistryApi, api
     end
   end
+
+  describe '#api' do
+    let(:api) { subject.api }
+
+    test 'returns a RegistryApi instance' do
+      assert_kind_of Service::RegistryApi, api
+    end
+  end
 end

--- a/test/units/image_search_service_test.rb
+++ b/test/units/image_search_service_test.rb
@@ -1,0 +1,188 @@
+require 'test_plugin_helper'
+
+class ImageSearchServiceTest < ActiveSupport::TestCase
+  let(:compute_resource) { FactoryGirl.create(:docker_cr) }
+  let(:registry) { FactoryGirl.create(:docker_registry).api }
+  let(:term) { 'centos' }
+  let(:query) { { term: term, tags: 'false' } }
+
+  subject { ForemanDocker::ImageSearch.new(compute_resource, registry) }
+
+  setup do
+    stub_registry_api
+  end
+
+  describe '#add_source' do
+    setup do
+      subject.instance_variable_set(:@sources, {})
+    end
+
+    test 'adds a compute resource to @sources[:compute_resource]' do
+      subject.add_source(compute_resource)
+      assert_equal compute_resource,
+                   subject.instance_variable_get(:@sources)[:compute_resource].first
+    end
+
+    test 'adds a registry to @sources[:registry]' do
+      subject.add_source(registry)
+      assert_equal registry,
+                   subject.instance_variable_get(:@sources)[:registry].first
+    end
+  end
+
+  describe '#remove_source' do
+    test 'removes a registry source from @sources' do
+      refute subject.instance_variable_get(:@sources)[:registry].empty?
+      subject.remove_source(registry)
+      assert subject.instance_variable_get(:@sources)[:registry].empty?
+    end
+
+    test 'removes a compute_resource source from @sources' do
+      refute subject.instance_variable_get(:@sources)[:compute_resource].empty?
+      subject.remove_source(compute_resource)
+      assert subject.instance_variable_get(:@sources)[:compute_resource].empty?
+    end
+  end
+
+  describe '#search' do
+    test 'returns {"name" => value } pairs' do
+      return_result = Hash.new
+      return_result.stubs(:info).returns({ 'RepoTags' => ["#{term}:latest"]})
+      compute_resource.stubs(:local_images).with(term)
+        .returns([return_result])
+      result = subject.search(query)
+      assert_equal({"name" => term}, result.first)
+    end
+
+    context 'tags is false' do
+      test 'calls #images with term as query' do
+        subject.expects(:images).with(term)
+          .returns([])
+        subject.search(query)
+      end
+    end
+
+    context 'tags is "true"' do
+      setup do
+        query[:tags] = 'true'
+      end
+
+      test 'calls #tags with term as query' do
+        subject.expects(:tags).with(term)
+          .returns([])
+        subject.search(query)
+      end
+    end
+  end
+
+  describe '#images' do
+    context 'a compute_resource set' do
+      test 'calls #search_compute_resource with term as query' do
+        subject.expects(:compute_resource_search).with(compute_resource, term)
+          .returns([])
+        subject.images(term)
+      end
+    end
+
+    context 'no compute_resource is set' do
+      setup do
+        subject.remove_source(compute_resource)
+      end
+
+      test 'does not call #search_compute_resource' do
+        subject.expects(:compute_resource_search).with(compute_resource, term)
+          .never
+        subject.images(term)
+      end
+    end
+
+    context 'a registry is set' do
+      test 'calls #search_registry' do
+        subject.expects(:registry_search).with(registry, term)
+          .returns([])
+        subject.images(term)
+      end
+    end
+
+    context 'no registry is set' do
+      setup do
+        subject.remove_source(registry)
+      end
+
+      test 'does not call #search_registry' do
+        subject.expects(:registry_search).with(registry, term)
+          .never
+        subject.images(term)
+      end
+    end
+  end
+
+  describe '#tags' do
+    let(:tag) { 'latest' }
+    let(:query) { "#{term}:#{tag}" }
+
+    context 'a compute_resource set' do
+      test 'calls #compute_resource with image name and tag' do
+        subject.expects(:compute_resource_tags).with(compute_resource, term, tag)
+          .returns([])
+        subject.tags(query)
+      end
+    end
+
+    context 'no compute_resource is set' do
+      setup do
+        subject.remove_source(compute_resource)
+      end
+
+      test 'does not call #search_compute_resource' do
+        subject.expects(:compute_resource_tags).with(compute_resource, term, tag)
+          .never
+        subject.tags(query)
+      end
+    end
+
+    context 'a registry is set' do
+      setup do
+        subject.remove_source(compute_resource)
+      end
+
+      test 'calls #registry_tags with image name and tag' do
+        subject.expects(:registry_tags).with(registry, term, tag)
+          .returns([])
+        subject.tags(query)
+      end
+    end
+
+    context 'no registry is set' do
+      setup do
+        subject.remove_source(registry)
+      end
+
+      test 'does not call #registry_tags' do
+        subject.expects(:registry_search).with(registry, term, tag)
+          .never
+        subject.images(query)
+      end
+    end
+  end
+
+  describe '#available?' do
+    test 'calls #tags with query' do
+      subject.expects(:tags).with(query).once
+        .returns([])
+      subject.available?(query)
+    end
+
+    test 'returns true if any matching image and tag is found' do
+      subject.stubs(:tags).with(query)
+        .returns([{ 'name' => "#{term}:latest" }])
+      subject.available?(query)
+    end
+
+    test 'returns false if none are found' do
+      subject.stubs(:tags).with(query)
+        .returns([])
+      subject.available?(query)
+    end
+  end
+end


### PR DESCRIPTION
When searching for an external registry the search would show results from Docker Hub due to it searching via the compute resource.

By using a registry parameter to indicate which search tab is active this gets prevented on the backend as well as on the client by not searching when no registry is selected.

Once #184 is merged I will rebase this branch and the changes only regarding this fix will remain.