### PR TITLE
Fixes #16235 - Add verify SSL option for Registries

### DIFF
--- a/app/assets/javascripts/foreman_docker/create_registry.js
+++ b/app/assets/javascripts/foreman_docker/create_registry.js
@@ -1,0 +1,15 @@
+function toggleVerifySSL () {
+  var urlField = $('#docker_registry_url'),
+      verifySSLField = $('#docker_registry_verify_ssl'),
+      verifySSLFormGroup = verifySSLField.closest('.form-group');
+
+  if (/^https/.test(urlField.val())) {
+    verifySSLFormGroup.show();
+  } else {
+    verifySSLFormGroup.hide();
+  };
+};
+
+$(document).ready(function () {
+  $('#docker_registry_url').on('change', toggleVerifySSL)
+})

--- a/app/controllers/concerns/foreman/controller/parameters/docker_registry.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/docker_registry.rb
@@ -4,7 +4,7 @@ module Foreman::Controller::Parameters::DockerRegistry
   class_methods do
     def docker_registry_params_filter
       Foreman::ParameterFilter.new(::DockerRegistry).tap do |filter|
-        filter.permit :name, :url, :username, :password, :description,
+        filter.permit :name, :url, :username, :password, :description, :verify_ssl,
                       :location_ids => [], :organization_ids => []
       end
     end

--- a/app/models/docker_registry.rb
+++ b/app/models/docker_registry.rb
@@ -44,14 +44,18 @@ class DockerRegistry < ActiveRecord::Base
 
   def api
     @api ||= Service::RegistryApi.new(url: url, user: username,
-                                      password: password)
+                                      password: password, verify_ssl: verify_ssl)
   end
 
   private
 
   def attempt_login
     api.ok?
-  rescue => e
-    errors.add(:base, _('Unable to log in to this Docker Registry - %s') % e)
+  rescue Excon::Error::Certificate
+    message = 'Unable to verify certificate.\
+              (Disable "Verify ssl" if you still want to use this Docker Registry)'
+    errors.add(:base, _(message))
+  rescue => error
+    errors.add(:base, _('Unable to log in to this Docker Registry - %s') % error)
   end
 end

--- a/app/views/registries/_form.html.erb
+++ b/app/views/registries/_form.html.erb
@@ -1,3 +1,4 @@
+<%= javascript 'foreman_docker/create_registry' %>
 <%= form_for @registry, :url => (@registry.new_record? ? registries_path : registry_path(:id => @registry.id)) do |f| %>
     <%= base_errors_for @registry %>
     <ul class="nav nav-tabs" data-tabs="tabs">
@@ -14,9 +15,10 @@
       <div class="tab-pane active" id="primary">
         <%= text_f   f, :name %>
         <%= text_f   f, :url %>
-        <%= text_f   f, :description, :help_inline => _("Description of the registry") %>
-        <%= text_f   f, :username, :help_inline => _("Username used to access the registry") %>
-        <%= password_f   f, :password, :help_inline => _("Password used for authentication to the registry") %>
+        <%= text_f   f, :description, :label_help => _("Description of the registry") %>
+        <%= text_f   f, :username, :label_help => _("Username used to access the registry") %>
+        <%= password_f   f, :password, :label_help => _("Password used for authentication to the registry") %>
+        <%= checkbox_f f, :verify_ssl, :label_help => _("Disable to use an insecure registry"), :wrapper_class => 'form-group hidden' %>
       </div>
 
       <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @registry %>

--- a/app/views/registries/index.html.erb
+++ b/app/views/registries/index.html.erb
@@ -3,16 +3,16 @@
 <%= title_actions(new_link(_("Create Registry"))) %>
 
 <table class="table table-bordered table-striped table-condensed" data-table="inline">
+  <thead>
+    <tr>
+      <th><%= sort :name, :as => _("Name") %></th>
+      <th class="hidden-tablet hidden-xs"><%= sort :url, :as => _("URL") %></th>
+      <th class="hidden-tablet hidden-xs"><%= _("Description") %></th>
+      <th><%= _('Actions') %></th>
+    </tr>
   </thead>
-  <tr>
-    <th class="text-center"><%= sort :name, :as => _("Name") %></th>
-    <th class="hidden-tablet hidden-xs text-center"><%= sort :url, :as => _("URL") %></th>
-    <th class="hidden-tablet hidden-xs text-center"><%= _("Description") %></th>
-    <th><%= _('Actions') %></th>
-  </tr>
-  </thead>
-
-  <% @registries.each do |r| %>
+  <tbody>
+    <% @registries.each do |r| %>
       <tr>
         <td><%= link_to_if_authorized trunc_with_tooltip(r.name), hash_for_edit_registry_path(:id => r).merge(:auth_object => r, :authorizer => authorizer) %></td>
         <td class="hidden-tablet hidden-xs text-center"><%= trunc_with_tooltip(r.url) %></td>
@@ -22,7 +22,8 @@
           merge(:auth_object => r, :authorizer => authorizer),
           :confirm => _("Delete %s?") % r.name) %></td>
       </tr>
-  <% end %>
+    <% end %>
+  </tbody>
 </table>
 
 <%= will_paginate_with_info @registries %>

--- a/db/migrate/20170508130316_add_verify_ssl_option_to_docker_registries.rb
+++ b/db/migrate/20170508130316_add_verify_ssl_option_to_docker_registries.rb
@@ -1,0 +1,5 @@
+class AddVerifySslOptionToDockerRegistries < ActiveRecord::Migration
+  def change
+    add_column :docker_registries, :verify_ssl, :boolean, default: true
+  end
+end

--- a/lib/foreman_docker/engine.rb
+++ b/lib/foreman_docker/engine.rb
@@ -20,17 +20,18 @@ module ForemanDocker
       end
     end
 
+    foreman_docker_assets = %w[foreman_docker/autocomplete.css
+                               foreman_docker/terminal.css
+                               foreman_docker/image_step.js
+                               foreman_docker/create_registry.js]
+
     initializer "foreman_docker.assets.precompile" do |app|
-      app.config.assets.precompile += %w(foreman_docker/autocomplete.css
-                                         foreman_docker/terminal.css
-                                         foreman_docker/image_step.js)
+      app.config.assets.precompile += foreman_docker_assets
     end
 
     initializer 'foreman_docker.configure_assets', :group => :assets do
       SETTINGS[:foreman_docker] =
-        { :assets => { :precompile => ['foreman_docker/autocomplete.css',
-                                       'foreman_docker/terminal.css',
-                                       'foreman_docker/image_step.js'] } }
+        { :assets => { :precompile => foreman_docker_assets } }
     end
 
     initializer 'foreman_docker.register_gettext', :after => :load_config_initializers do

--- a/test/integration/registry_creation_test.rb
+++ b/test/integration/registry_creation_test.rb
@@ -1,0 +1,19 @@
+require 'integration_test_helper'
+
+class RegistryiCreationTest < IntegrationTestWithJavascript
+  let(:registry_values) { FactoryGirl.build(:docker_registry) }
+
+  setup do
+    DockerRegistry.any_instance.stubs(:attempt_login).returns(true)
+    visit new_registry_path
+  end
+
+  test 'can create a registy' do
+    assert_difference('DockerRegistry.count') do
+      fill_in 'docker_registry_name', with: registry_values.name
+      fill_in 'docker_registry_url', with: registry_values.url
+      page.find('#new_docker_registry .btn-primary').click
+      wait_for_ajax
+    end
+  end
+end

--- a/test/units/docker_registry_test.rb
+++ b/test/units/docker_registry_test.rb
@@ -55,12 +55,4 @@ class DockerRegistryTest < ActiveSupport::TestCase
       assert_kind_of Service::RegistryApi, api
     end
   end
-
-  describe '#api' do
-    let(:api) { subject.api }
-
-    test 'returns a RegistryApi instance' do
-      assert_kind_of Service::RegistryApi, api
-    end
-  end
 end

--- a/test/units/registry_api_test.rb
+++ b/test/units/registry_api_test.rb
@@ -30,6 +30,15 @@ class RegistryApiTest < ActiveSupport::TestCase
         assert_equal password, subject.connection.options[:password]
       end
     end
+
+    context 'verify ssl is set' do
+      let(:verify_ssl) { [true, false].sample }
+      subject { Service::RegistryApi.new(url: url, verify_ssl: verify_ssl) }
+
+      test 'it passes it as ssl_verify_peer' do
+        assert_equal verify_ssl, subject.connection.options[:ssl_verify_peer]
+      end
+    end
   end
 
   describe '#get' do
@@ -185,8 +194,11 @@ class RegistryApiTest < ActiveSupport::TestCase
 
   describe '#ok?' do
     test 'calls the API via #get with /v1/' do
+      params = subject.send(:default_connection_options)
+                      .merge(subject.send(:credentials))
+                      .merge(path: '/v1/')
       subject.connection.expects(:get)
-             .with('/', nil, Service::RegistryApi::DEFAULTS[:connection].merge(path: '/v1/'))
+             .with('/', nil, params)
              .returns('Docker Registry API')
       assert subject.ok?
     end


### PR DESCRIPTION
To allow using registries with an invalid certificate
the "Verify ssl" option disables verification for
connections to a registry.