### PR TITLE
Fixes #19964 - Use ApplicationRecord instead of ActiveRecord::Base

### DIFF
--- a/app/models/container.rb
+++ b/app/models/container.rb
@@ -1,4 +1,4 @@
-class Container < ActiveRecord::Base
+class Container < ApplicationRecord
   include Authorizable
   include Taxonomix
 

--- a/app/models/docker_container_wizard_state.rb
+++ b/app/models/docker_container_wizard_state.rb
@@ -1,4 +1,4 @@
-class DockerContainerWizardState < ActiveRecord::Base
+class DockerContainerWizardState < ApplicationRecord
   has_one :preliminary, :class_name => DockerContainerWizardStates::Preliminary,
                         :dependent => :destroy, :validate => true, :autosave => true
   has_one :image, :class_name => DockerContainerWizardStates::Image,

--- a/app/models/docker_container_wizard_states/configuration.rb
+++ b/app/models/docker_container_wizard_states/configuration.rb
@@ -1,5 +1,5 @@
 module DockerContainerWizardStates
-  class Configuration < ActiveRecord::Base
+  class Configuration < ApplicationRecord
     self.table_name_prefix = 'docker_container_wizard_states_'
     belongs_to :wizard_state, :class_name => DockerContainerWizardState,
                               :foreign_key => :docker_container_wizard_state_id

--- a/app/models/docker_container_wizard_states/environment.rb
+++ b/app/models/docker_container_wizard_states/environment.rb
@@ -1,5 +1,5 @@
 module DockerContainerWizardStates
-  class Environment < ActiveRecord::Base
+  class Environment < ApplicationRecord
     self.table_name_prefix = 'docker_container_wizard_states_'
     belongs_to :wizard_state, :class_name => DockerContainerWizardState
 

--- a/app/models/docker_container_wizard_states/image.rb
+++ b/app/models/docker_container_wizard_states/image.rb
@@ -1,5 +1,5 @@
 module DockerContainerWizardStates
-  class Image < ActiveRecord::Base
+  class Image < ApplicationRecord
     self.table_name_prefix = 'docker_container_wizard_states_'
     belongs_to :wizard_state, :class_name => DockerContainerWizardState,
                               :foreign_key => :docker_container_wizard_state_id

--- a/app/models/docker_container_wizard_states/preliminary.rb
+++ b/app/models/docker_container_wizard_states/preliminary.rb
@@ -1,5 +1,5 @@
 module DockerContainerWizardStates
-  class Preliminary < ActiveRecord::Base
+  class Preliminary < ApplicationRecord
     include Taxonomix
 
     self.table_name_prefix = 'docker_container_wizard_states_'

--- a/app/models/docker_parameter.rb
+++ b/app/models/docker_parameter.rb
@@ -1,4 +1,4 @@
-class DockerParameter < ActiveRecord::Base
+class DockerParameter < ApplicationRecord
   extend FriendlyId
   friendly_id :key
   include Parameterizable::ByIdName

--- a/app/models/docker_registry.rb
+++ b/app/models/docker_registry.rb
@@ -1,4 +1,4 @@
-class DockerRegistry < ActiveRecord::Base
+class DockerRegistry < ApplicationRecord
   include Authorizable
   include Taxonomix
   include Encryptable


### PR DESCRIPTION
Not mergable yet, as using `ApplicationRecord` for `DockerContainerWizardState` raises `NoMethodError: undefined method 'has_one' for main:Object`.

Not sure yet why this occurs.