### PR TITLE
Fixes #20355 - Request registry results in JSON

### DIFF
--- a/app/models/service/registry_api.rb
+++ b/app/models/service/registry_api.rb
@@ -1,9 +1,10 @@
 module Service
   class RegistryApi
-    DOCKER_HUB = 'https://registry.hub.docker.com/'.freeze
+    DOCKER_HUB = 'https://index.docker.io/'.freeze
     DEFAULTS = {
       url: 'http://localhost:5000'.freeze,
-      connection: { omit_default_port: true }
+      connection: { omit_default_port: true,
+                    headers: { "Content-Type" => "application/json" }}
     }
 
     attr_accessor :config, :url

--- a/test/units/registry_api_test.rb
+++ b/test/units/registry_api_test.rb
@@ -13,6 +13,10 @@ class RegistryApiTest < ActiveSupport::TestCase
       assert_equal url, subject.connection.url
     end
 
+    test 'it requests json' do
+      assert_equal 'application/json', subject.connection.options[:headers]['Content-Type']
+    end
+
     context 'authentication is set' do
       let(:user) { 'username' }
       let(:password) { 'secretpassword' }


### PR DESCRIPTION
Docker Hub seemed to have stopped defaulting to JSON.
Requesting the right content type and updating the URL to the endpoint used by the official client.